### PR TITLE
Fix environment variable export instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -91,7 +91,7 @@ For this reason, it is disabled
 To bring up a graphical interface _with_ mutation support:
 ```sh
 cd uwflow2.0/backend/hasura
-source ../.env
+export $(cat ../.env | xargs)
 hasura console
 ```
 This should ideally happen automatically;


### PR DESCRIPTION
I hadn't tested this line in POSIX shells, so it turns out it doesn't quite work as `source` does _not_ export variable declarations. This fixes that.