### PR TITLE
Bump Hasura and Postgres versions

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD
       POSTGRES_PORT: $POSTGRES_PORT
       POSTGRES_USER: $POSTGRES_USER
-    image: postgres:11.2-alpine
+    image: postgres:12-alpine
     ports:
       - $POSTGRES_PORT:$POSTGRES_PORT
     restart: always
@@ -20,9 +20,10 @@ services:
     environment:
       HASURA_GRAPHQL_ADMIN_SECRET: $HASURA_GRAPHQL_ADMIN_SECRET
       HASURA_GRAPHQL_DATABASE_URL: postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres:$POSTGRES_PORT/$POSTGRES_DB
+      HASURA_GRAPHQL_ENABLED_LOG_TYPES: "http-log, query-log, startup"
       HASURA_GRAPHQL_ENABLE_CONSOLE: "false"  # Must be run manually to track migrations
       HASURA_GRAPHQL_ENABLE_TELEMETRY: "false"  # Why is this even enabled by default?!
-    image: hasura/graphql-engine:v1.0.0-beta.1.cli-migrations
+    image: hasura/graphql-engine:v1.0.0-beta.3.cli-migrations
     ports:
       - $API_PORT:$API_PORT
     restart: always


### PR DESCRIPTION
This is fairly self-explanatory: new versions came out while we weren't looking.

Notably, Hasura now allows us to log generated SQL via `query-log`. It's pretty neat, so I enabled it.