### PR TITLE
Add prof code and index course numbers for search

### DIFF
--- a/backend/hasura/migrations/1559740220527_init/up.yaml
+++ b/backend/hasura/migrations/1559740220527_init/up.yaml
@@ -1240,12 +1240,14 @@
             allow_aggregations: true
             columns:
               - course_ids
+              - course_codes
               - prof_id
               - ratings
               - clear
               - engaging
               - liked
               - name
+              - code
             filter: {}
           role: anonymous
         - comment: null
@@ -1253,12 +1255,14 @@
             allow_aggregations: true
             columns:
               - course_ids
+              - course_codes
               - prof_id
               - ratings
               - clear
               - engaging
               - liked
               - name
+              - code
             filter: {}
           role: user
       table: prof_search_index


### PR DESCRIPTION
- Indexing course numbers to allow search results for split queries such as "ECE 105" or queries with only numbers such as "105"
- Add prof code to prof results for generating links in the frontend
- Prof results also returns a list of course `code` with courses profs are teaching for filtering