### PR TITLE
Proper webcal timezones, unbreak tuesdays and downloads

### DIFF
--- a/backend/flow/api/calendar/timezone.go
+++ b/backend/flow/api/calendar/timezone.go
@@ -1,0 +1,17 @@
+package calendar
+
+import (
+	"log"
+	"time"
+)
+
+var UniversityLocation *time.Location
+
+func init() {
+	var err error
+	// Toronto is the canonical location for the zone containing UW
+	UniversityLocation, err = time.LoadLocation("America/Toronto")
+	if err != nil {
+		log.Fatalf("Error: %s", err)
+	}
+}


### PR DESCRIPTION
## Summary

Basically title. To expand:

1. Google seemingly treats floating times (that is, `RFC5545 3.3.5(1)`) as UTC, so we have to do proper timezones. This is not trivial because everywhere else sections arise we treat them as "pictures of a clock" instead of true timestamps, so they are stored as seconds-of-day wrt `America/Toronto`. This is either `EDT` or `EST` depending on time of year, so translating to `UTC` is not as simple as a single offset. In the end, I get string dates form Postgres and parse them in the proper location.
2. Tuesdays were, embarrassingly, broken: the code is `T` and not `Tu`. This is fixed.
3. `http.Request.URL.Scheme` will never actually contain anything except `http` because Nginx connects to API via http. `Content-Disposition` is harmless anyway, so I'll be setting it all the time from now on.