### PR TITLE
Change ratings to between 0 and 4 for frontend display

### DIFF
--- a/backend/flow/importer/mongo/parts/review.go
+++ b/backend/flow/importer/mongo/parts/review.go
@@ -61,9 +61,7 @@ func (r *MongoReview) Empty() bool {
 	return r.CourseReview.Empty() && r.ProfReview.Empty()
 }
 
-// Translate from binary to binned: (0 1) for liked or (0 1 2 3 4 5) for others.
-// We typically want to make the translation "soft" by mapping
-// to medium intensity ratings and not extremes (e.g. false -> 1, true -> 4).
+// Translate from binary to binned: (0 1) for liked or (0 1 2 3 4) for others.
 func rescaledRating(value *float64, falseValue, trueValue int16) *int16 {
 	if value == nil {
 		return nil
@@ -168,11 +166,11 @@ func ImportReviews(state *state.State, idMap *IdentifierMap) error {
 				ProfId:        util.NilIfZero(profId),
 				UserId:        &userId,
 				Liked:         rescaledRating(courseReview.Interest, 0, 1),
-				CourseEasy:    rescaledRating(courseReview.Easiness, 0, 5),
-				CourseUseful:  rescaledRating(courseReview.Usefulness, 0, 5),
+				CourseEasy:    rescaledRating(courseReview.Easiness, 0, 4),
+				CourseUseful:  rescaledRating(courseReview.Usefulness, 0, 4),
 				CourseComment: util.NilIfEmpty(courseReview.Comment),
-				ProfClear:     rescaledRating(profReview.Clarity, 0, 5),
-				ProfEngaging:  rescaledRating(profReview.Passion, 0, 5),
+				ProfClear:     rescaledRating(profReview.Clarity, 0, 4),
+				ProfEngaging:  rescaledRating(profReview.Passion, 0, 4),
 				ProfComment:   util.NilIfEmpty(profReview.Comment),
 				Public:        courseReview.Privacy == Public,
 				CreatedAt:     created,
@@ -305,8 +303,8 @@ func ImportLegacyReviews(state *state.State, idMap *IdentifierMap) error {
 				CourseId:    courseId,
 				ProfId:      util.NilIfZero(profId),
 				Liked:       rescaledRating(courseReview.Interest, 0, 1),
-				CourseEasy:  rescaledRating(courseReview.Easiness, 0, 5),
-				ProfClear:   rescaledRating(profReview.Clarity, 0, 5),
+				CourseEasy:  rescaledRating(courseReview.Easiness, 0, 4),
+				ProfClear:   rescaledRating(profReview.Clarity, 0, 4),
 				ProfComment: util.NilIfEmpty(profReview.Comment),
 				Public:      false,
 				Legacy:      true,

--- a/backend/hasura/migrations/1559740220527_init/up.sql
+++ b/backend/hasura/migrations/1559740220527_init/up.sql
@@ -191,15 +191,15 @@ CREATE TABLE review (
   liked SMALLINT
     CONSTRAINT liked_range CHECK (0 <= liked AND liked <= 1),
   course_easy SMALLINT
-    CONSTRAINT easy_range CHECK (0 <= course_easy AND course_easy <= 5),
+    CONSTRAINT easy_range CHECK (0 <= course_easy AND course_easy <= 4),
   course_useful SMALLINT
-    CONSTRAINT useful_range CHECK (0 <= course_useful AND course_useful <= 5),
+    CONSTRAINT useful_range CHECK (0 <= course_useful AND course_useful <= 4),
   course_comment TEXT
     CONSTRAINT course_comment_length CHECK (LENGTH(course_comment) <= 8192),
   prof_clear SMALLINT
-    CONSTRAINT clear_range CHECK (0 <= prof_clear AND prof_clear <= 5),
+    CONSTRAINT clear_range CHECK (0 <= prof_clear AND prof_clear <= 4),
   prof_engaging SMALLINT
-    CONSTRAINT engaging_range CHECK (0 <= prof_engaging AND prof_engaging <= 5),
+    CONSTRAINT engaging_range CHECK (0 <= prof_engaging AND prof_engaging <= 4),
   prof_comment TEXT
     CONSTRAINT prof_comment_length CHECK (LENGTH(prof_comment) <= 8192),
   public BOOLEAN NOT NULL,
@@ -348,8 +348,8 @@ SELECT
   COUNT(r.liked)           AS filled_count,
   COUNT(r.course_comment)  AS comment_count,
   AVG(r.liked)             AS liked,
-  AVG(r.course_easy) / 5   AS easy,
-  AVG(r.course_useful) / 5 AS useful
+  AVG(r.course_easy) / 4   AS easy,
+  AVG(r.course_useful) / 4 AS useful
 FROM course
   LEFT JOIN review r ON course.id = r.course_id
 GROUP BY course.id;
@@ -360,8 +360,8 @@ SELECT
   COUNT(r.liked)           AS filled_count,
   COUNT(r.prof_comment)    AS comment_count,
   AVG(r.liked)             AS liked,
-  AVG(r.prof_clear) / 5    AS clear,
-  AVG(r.prof_engaging) / 5 AS engaging
+  AVG(r.prof_clear) / 4    AS clear,
+  AVG(r.prof_engaging) / 4 AS engaging
 FROM prof
   LEFT JOIN review r ON prof.id = r.prof_id
 GROUP BY prof.id;


### PR DESCRIPTION
Ratings are now from 0 to 4, which means options now include neutral ratings. For example, easy ratings become "Difficult, Somewhat difficult, Neutral, Somewhat easy, Easy".

The reason is that empty circles on the frontend for a rating of 0 looks like the rating does not exist, so I'd prefer to have between 1 and 5 circles. This also provides a "softer" transition between old binary ratings (easy, not easy) to the new rating system since we removed the "very easy" and "very difficult" ratings and now map them to "easy" or "difficult" instead. Also people tend to rate at the extremes anyways, so I don't think including "Neutral" would be too detrimental to our scoring system.

Here's what it looks like on frontend (relevant PR at https://github.com/AyushK1/uwflow2.0_frontend/pull/111):

![image](https://user-images.githubusercontent.com/21136804/72039521-7a238f00-3273-11ea-9838-297da5082fd7.png)
