### PR TITLE
Return failed class imports for schedule instead of error

### DIFF
--- a/backend/flow/api/parse/parse.go
+++ b/backend/flow/api/parse/parse.go
@@ -107,8 +107,8 @@ func HandleTranscript(tx *db.Tx, r *http.Request) (interface{}, error) {
 }
 
 type scheduleResponse struct {
-	SectionsImported int `json:"sections_imported"`
-	FailedClasses []int `json:"failed_classes"`
+	SectionsImported int   `json:"sections_imported"`
+	FailedClasses    []int `json:"failed_classes"`
 }
 
 const deleteCourseTakenQuery = `


### PR DESCRIPTION
* Allows other classes to still be imported properly and ignores the bad ones