### PR TITLE
Allow transcript parsing of two letter academic levels (NL)

### DIFF
--- a/backend/flow/api/parse/transcript/transcript.go
+++ b/backend/flow/api/parse/transcript/transcript.go
@@ -33,7 +33,7 @@ var (
 	// (e.g. course equivalences established during program transfer)
 	CourseRegexp    = regexp.MustCompile(`([A-Z]{2,})\x20{2,}(\d{1,3}\w*)\x20{2,}.*\n`)
 	CreditRegexp    = regexp.MustCompile(`\d.\d{2}`)
-	LevelRegexp     = regexp.MustCompile(`Level:\s+(\w\w)`)
+	LevelRegexp     = regexp.MustCompile(`Level:\s+(\w{2,})`)
 	StudentIdRegexp = regexp.MustCompile(`Student ID:\s+(\d+)`)
 	TermRegexp      = regexp.MustCompile(`(Fall|Winter|Spring)\s+(\d{4})`)
 )


### PR DESCRIPTION
* Fixes a few transcript upload errors with academic level NL on some terms
* Works locally when tested