### PR TITLE
Start writing course stubs to database

### DIFF
--- a/backend/flow/importer/uw/parts/course/struct.go
+++ b/backend/flow/importer/uw/parts/course/struct.go
@@ -26,12 +26,6 @@ type Antireq struct {
 	AntireqCode string
 }
 
-// Data necessary to uniquely identify a course, equivalent to a course code
-type ApiCourseHandle struct {
-	Subject string `json:"subject"`
-	Number  string `json:"catalog_number"`
-}
-
 type ApiCourse struct {
 	Subject     string `json:"subject"`
 	Number      string `json:"catalog_number"`


### PR DESCRIPTION
Following my discussion with @edwinzhng, it is probably useful to save courses in the DB even if they don't have an extended description at `course/SUBJECT/NUMBER`. 

Unfortunately, the titles often don't agree between extended and non-extended descriptions, with non-extended descriptions having such wonderful titles as
```
Int Macroec Anlys for Mgt(WLU)
```
or [sic!]
```
Info Sys Dev, Ctrl&Audit (WLU
```
Perhaps it would be best to simply add these courses manually and not merge this PR. I'm putting it out since I have the code anyway, but treat it as a request for comments.