### PR TITLE
Keep previous term's sections in Hasura

### DIFF
--- a/backend/flow/importer/uw/parts/section/import.go
+++ b/backend/flow/importer/uw/parts/section/import.go
@@ -12,7 +12,7 @@ import (
 
 func ImportAll(state *state.State, client *api.Client) error {
 	var converted ConvertResult
-	termIds := []int{util.CurrentTermId(), util.NextTermId()}
+	termIds := []int{util.PreviousTermId(), util.CurrentTermId(), util.NextTermId()}
 
 	for _, termId := range termIds {
 		apiSections, err := FetchByTerm(client, termId)

--- a/backend/flow/importer/uw/parts/section/vacuum.go
+++ b/backend/flow/importer/uw/parts/section/vacuum.go
@@ -26,8 +26,8 @@ WHERE NOT EXISTS (
 
 func Vacuum(state *state.State) error {
 	log.StartVacuum("section")
-	// Retain only sections starting with the current term
-	tag, err := state.Db.Exec(DeleteSectionQuery, util.CurrentTermId())
+	// Retain only sections starting with the previous term
+	tag, err := state.Db.Exec(DeleteSectionQuery, util.PreviousTermId())
 	if err != nil {
 		return fmt.Errorf("deleting old sections: %w", err)
 	}


### PR DESCRIPTION
This is a temporary measure. I expect to add a historical `prof_taught_course` table tomorrow to allow reviewing historical offerings; however, right now there is a problem: the previous term is already gone, so users can't review their very recent offerings. This should be fixed immediately, and luckily the fix is very simple: this.