### PR TITLE
Bump Hasura to close security hole

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       HASURA_GRAPHQL_ENABLE_TELEMETRY: "false"  # Why is this even enabled by default?!
       HASURA_GRAPHQL_JWT_SECRET: '{"type": "HS256", "key": "${HASURA_GRAPHQL_JWT_KEY}"}'
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: $HASURA_GRAPHQL_UNAUTHORIZED_ROLE
-    image: hasura/graphql-engine:v1.2.0.cli-migrations-v2
+    image: hasura/graphql-engine:v1.2.1.cli-migrations-v2
     ports:
       - $HASURA_PORT:$HASURA_PORT
     restart: always


### PR DESCRIPTION
A security bulletin went out 10 minutes ago declaring v1.2.0 vulnerable. Should upgrade ASAP.