### PR TITLE
importer/uw: start importing course stubs

### DIFF
--- a/backend/flow/importer/uw/parts/course/fetch.go
+++ b/backend/flow/importer/uw/parts/course/fetch.go
@@ -13,75 +13,63 @@ type Semaphore chan empty
 const RateLimit = 20
 
 func FetchAll(client *api.Client) ([]ApiCourse, error) {
-	handles, err := FetchHandles(client)
+	courses, err := fetchStubs(client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch handles: %w", err)
 	}
 
 	sema := make(Semaphore, RateLimit)
-	datachan := make(chan *ApiCourse, len(handles))
-	errorchan := make(chan error, len(handles))
-	for _, handle := range handles {
-		go asyncFetchByHandle(client, handle, sema, datachan, errorchan)
+	errch := make(chan error, len(courses))
+	for i := range courses {
+		go asyncFillStub(client, &courses[i], sema, errch)
 	}
 
-	courses := make([]ApiCourse, len(handles))
-	for i := 0; i < len(handles); i++ {
-		select {
-		case course := <-datachan:
-			courses[i] = *course
-		case err := <-errorchan:
+	for i := 0; i < len(courses); i++ {
+		err = <-errch
+		if err != nil {
 			return nil, err
 		}
 	}
+
 	return courses, nil
 }
 
-func asyncFetchByHandle(
-	client *api.Client, handle ApiCourseHandle,
-	sema Semaphore, datachan chan *ApiCourse, errorchan chan error,
-) {
+func asyncFillStub(client *api.Client, stub *ApiCourse, sema Semaphore, errch chan error) {
 	sema <- empty{}
-	course, err := FetchByHandle(client, handle)
-	if err != nil {
-		errorchan <- err
-	} else {
-		datachan <- course
-	}
+	errch <- fillStub(client, stub)
 	<-sema
 }
 
-func FetchByHandle(client *api.Client, handle ApiCourseHandle) (*ApiCourse, error) {
-	var course ApiCourse
-	endpoint := fmt.Sprintf("courses/%s/%s", handle.Subject, handle.Number)
-	err := client.Getv2(endpoint, &course)
-	return &course, err
+func fillStub(client *api.Client, stub *ApiCourse) error {
+	endpoint := fmt.Sprintf("courses/%s/%s", stub.Subject, stub.Number)
+	return client.Getv2(endpoint, &stub)
 }
 
-func FetchHandles(client *api.Client) ([]ApiCourseHandle, error) {
-	handles := make([]ApiCourseHandle, 0)
-	seenHandle := make(map[string]bool)
+// fetchStubs fetches {subject, number, name} in ApiCourse.
+func fetchStubs(client *api.Client) ([]ApiCourse, error) {
+	var stubs []ApiCourse
+	seenStub := make(map[string]bool)
 	// We are only intersted in the two upcoming terms
 	termIds := []int{util.CurrentTermId(), util.NextTermId()}
-	// Fetch hanles termwise with deduplication
+	// Fetch stubs termwise with deduplication
 	for _, termId := range termIds {
-		termHandles, err := FetchHandlesByTerm(client, termId)
+		termStubs, err := fetchStubsByTerm(client, termId)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch term %d: %w", termId, err)
 		}
-		for _, handle := range termHandles {
-			if !seenHandle[handle.Subject+handle.Number] {
-				handles = append(handles, handle)
-				seenHandle[handle.Subject+handle.Number] = true
+		for _, stub := range termStubs {
+			if !seenStub[stub.Subject+stub.Number] {
+				stubs = append(stubs, stub)
+				seenStub[stub.Subject+stub.Number] = true
 			}
 		}
 	}
-	return handles, nil
+	return stubs, nil
 }
 
-func FetchHandlesByTerm(client *api.Client, termId int) ([]ApiCourseHandle, error) {
-	var handles []ApiCourseHandle
+func fetchStubsByTerm(client *api.Client, termId int) ([]ApiCourse, error) {
+	var stubs []ApiCourse
 	endpoint := fmt.Sprintf("terms/%d/courses", termId)
-	err := client.Getv2(endpoint, &handles)
-	return handles, err
+	err := client.Getv2(endpoint, &stubs)
+	return stubs, err
 }

--- a/backend/flow/importer/uw/parts/course/insert.go
+++ b/backend/flow/importer/uw/parts/course/insert.go
@@ -19,6 +19,7 @@ UPDATE course SET
   antireqs = delta.antireqs
 FROM work.course_delta delta
 WHERE course.code = delta.code
+AND NOT course.authoritative
 `
 
 const InsertCourseQuery = `

--- a/backend/flow/importer/uw/parts/course/struct.go
+++ b/backend/flow/importer/uw/parts/course/struct.go
@@ -26,12 +26,6 @@ type Antireq struct {
 	AntireqCode string
 }
 
-// Data necessary to uniquely identify a course, equivalent to a course code
-type ApiCourseHandle struct {
-	Subject string `json:"subject"`
-	Number  string `json:"catalog_number"`
-}
-
 type ApiCourse struct {
 	Subject     string `json:"subject"`
 	Number      string `json:"catalog_number"`

--- a/backend/hasura/migrations/1559740220527_init/up.sql
+++ b/backend/hasura/migrations/1559740220527_init/up.sql
@@ -14,7 +14,9 @@ CREATE TABLE course (
   coreqs TEXT
     CONSTRAINT course_coreqs_length CHECK (LENGTH(coreqs) <= 1024),
   antireqs TEXT
-    CONSTRAINT course_antireqs_length CHECK (LENGTH(antireqs) <= 1024)
+    CONSTRAINT course_antireqs_length CHECK (LENGTH(antireqs) <= 1024),
+  -- Whether the entry has been amended. If so, do not overwrite with ADM data.
+  authoritative BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE course_antirequisite (


### PR DESCRIPTION
Although manual action is still required oftentimes, it would be easier for us to just let the importer save descriptionless course stubs if nothing better is available. Importantly, the `authoritative` tag will prevent it from overwriting our previous handcrafted data in so doing.