### PR TITLE
Add public schedule view and bump Hasura to 1.3.1

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       HASURA_GRAPHQL_ENABLE_TELEMETRY: "false"  # Why is this even enabled by default?!
       HASURA_GRAPHQL_JWT_SECRET: '{"type": "HS256", "key": "${HASURA_GRAPHQL_JWT_KEY}"}'
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: $HASURA_GRAPHQL_UNAUTHORIZED_ROLE
-    image: hasura/graphql-engine:v1.2.2.cli-migrations-v2
+    image: hasura/graphql-engine:v1.3.1
     ports:
       - $HASURA_PORT:$HASURA_PORT
     restart: always

--- a/backend/hasura/metadata/tables.yaml
+++ b/backend/hasura/metadata/tables.yaml
@@ -984,6 +984,53 @@
   delete_permissions: []
   event_triggers: []
   computed_fields: []
+  - table: public_user_schedule
+  is_enum: false
+  configuration:
+    custom_root_fields:
+      select: null
+      select_by_pk: null
+      select_aggregate: null
+      insert: null
+      update: null
+      delete: null
+    custom_column_names: {}
+  object_relationships:
+    - using:
+        foreign_key_constraint_on: section_id
+      name: section
+      comment: null
+    - using:
+        foreign_key_constraint_on: user_id
+      name: user
+      comment: null
+  array_relationships: []
+  insert_permissions: []
+  select_permissions:
+  - role: anonymous
+    comment: null
+    permission:
+      allow_aggregations: false
+      computed_fields: []
+      columns:
+        - secret_id
+        - section_id
+        - user_id
+      filter: {}
+  - role: user
+    comment: null
+    permission:
+      allow_aggregations: false
+      computed_fields: []
+      columns:
+        - secret_id
+        - section_id
+        - user_id
+        filter: {}
+  update_permissions: []
+  delete_permissions: []
+  event_triggers: []
+  computed_fields: []
 - table: review
   is_enum: false
   configuration:
@@ -1376,9 +1423,8 @@
     permission:
       set: {}
       columns:
-      - first_name
-      - last_name
       - email
+      - public_schedule
       filter:
         id:
           _eq: X-Hasura-User-Id

--- a/backend/hasura/migrations/1559740220527_init/up.sql
+++ b/backend/hasura/migrations/1559740220527_init/up.sql
@@ -87,7 +87,8 @@ CREATE TABLE "user" (
     CONSTRAINT email_length CHECK (LENGTH(email) <= 256)
     CONSTRAINT email_format CHECK (email ~* '^[A-Z0-9._%+*-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$'),
   join_source JOIN_SOURCE NOT NULL,
-  join_date TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  join_date TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  public_schedule BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE user_course_taken (
@@ -275,6 +276,15 @@ FROM review r
 CREATE VIEW review_user_id AS
 SELECT id AS review_id, user_id
 FROM review;
+
+CREATE VIEW public_user_schedule AS
+SELECT
+  secret_id,
+  section_id,
+  user_id
+FROM user_schedule us
+  LEFT JOIN "user" u ON us.user_id = u.id
+WHERE u.public_schedule = TRUE;
 
 -- END PUBLIC VIEWS
 


### PR DESCRIPTION
* Adds a `public_schedule` flag for users to enable schedule link sharing and a public schedule view
* Bumped Hasura to 1.3.1