### PR TITLE
Address potential leak and various code cleanup on pdftotext

### DIFF
--- a/flow/api/parse/pdf/pdftotext.cc
+++ b/flow/api/parse/pdf/pdftotext.cc
@@ -1,39 +1,59 @@
 #include <cstring>
 #include <string>
+#include <memory>
+#include <mutex>
 
-#include "poppler/cpp/poppler-document.h"
-#include "poppler/cpp/poppler-page.h"
+#include <poppler/cpp/poppler-document.h>
+#include <poppler/cpp/poppler-page.h>
 
+using std::size_t;
+using OnceFlag = std::once_flag;
 using String = std::string;
+template <typename T, typename Del = std::default_delete<T>>
+using UniquePtr = std::unique_ptr<T, Del>;
+
 using ByteArray = poppler::byte_array;
 using Document = poppler::document;
+using Page = poppler::page;
+
+namespace {
+    OnceFlag errorFnFlag;
+
+    void initErrorFunction() {
+        // Do not log errors from poppler to stderr
+        poppler::set_debug_error_function(
+            []([[maybe_unused]] const String& s, [[maybe_unused]] void* p) -> void {}, 
+            nullptr
+        );
+    }
+}
 
 extern "C" {
     [[nodiscard]]
-    const char* pdfToText(const char* data, int dataSize) noexcept {
-        static bool hasResetErrorFunction = false;
-        if (!hasResetErrorFunction) {
-            // Do not log errors from poppler to stderr
-            poppler::set_debug_error_function(
-                []([[maybe_unused]] const String& s, [[maybe_unused]] void* p) -> void {}, 
-                nullptr
-            );
-            hasResetErrorFunction = true;
-        }
+    const char* pdfToText(const char* data, size_t dataSize) noexcept {
+        std::call_once(errorFnFlag, initErrorFunction);
 
-        const Document* doc = Document::load_from_raw_data(data, dataSize);
+        UniquePtr<Document> doc(Document::load_from_raw_data(data, dataSize));
         if (!doc) {
             return nullptr;
         }
-        const int pageCount = doc->pages();
 
+        const int pageCount = doc->pages();
         String result;
+
         for (int i = 0; i < pageCount; ++i) {
-            ByteArray pageText = doc->create_page(i)->text().to_utf8();
+            UniquePtr<Page> page(doc->create_page(i));
+            if (!page) {
+                continue; // skip invalid pages
+            }
+            ByteArray pageText = page->text().to_utf8();
             result.append(pageText.begin(), pageText.end());
         }
 
-        char* buffer = (char*)std::malloc(result.length() + 1);
+        char* buffer = static_cast<char*>(std::malloc(result.length() + 1));
+        if (!buffer) {
+            return nullptr;
+        }
         std::memcpy(buffer, result.data(), result.length());
         buffer[result.length()] = '\0';
 

--- a/flow/api/parse/pdf/pdftotext.go
+++ b/flow/api/parse/pdf/pdftotext.go
@@ -3,10 +3,11 @@ package pdf
 // #cgo CFLAGS: -O2 -Wall -I/usr/include/poppler/cpp
 // #cgo LDFLAGS: -lpoppler-cpp
 // #include <stdlib.h>
-// const char *pdfToText(const char* data, int data_size);
+// const char* pdfToText(const char* data, size_t data_size);
 import "C"
 import (
 	"errors"
+	"runtime"
 	"unsafe"
 )
 
@@ -16,8 +17,13 @@ func ToText(data []byte) (string, error) {
 	// *provided* that C code does not attempt to find the end of the string,
 	// as []byte need not be zero-terminated.
 	// This is true for us, as C.pdfToText treats its first argument as bytes.
+	if len(data) == 0 {
+		return "", errors.New("empty PDF data")
+	}
+
 	cData := (*C.char)(unsafe.Pointer(&data[0]))
-	result := C.pdfToText(cData, C.int(len(data)))
+	result := C.pdfToText(cData, C.size_t(len(data)))
+	runtime.KeepAlive(data)
 	if result != nil {
 		converted := C.GoString(result)
 		C.free(unsafe.Pointer(result))


### PR DESCRIPTION
The previous `pdftotext.cc` used non-standard features such as VLAs and repeated `memcpy()` calls. This pull request replaces the VLA and `memcpy()` calls with direct string construction, and removes the no-op function, replacing it with a lambda. Also, because `poppler::document::load_from_raw_data()` returns a pointer, it makes sure to free `doc` by using a smart pointer and uses `std::call_once()` on `poppler::set_debug_error_function()` to prevent potential race condition if called by multiple goroutines.