### PR TITLE
Fix the current CI failure

### DIFF
--- a/flow/api/env/env.go
+++ b/flow/api/env/env.go
@@ -8,7 +8,7 @@ import (
 
 var Global env.Environment
 
-func init() {
+func Init() {
 	if err := env.Get(&Global); err != nil {
 		log.Fatalf("Error: %s", err)
 	}

--- a/flow/api/main.go
+++ b/flow/api/main.go
@@ -101,6 +101,7 @@ func setupRouter(conn *db.Conn) *chi.Mux {
 }
 
 func main() {
+	env.Init()
 	conn, err := db.ConnectPool(context.Background(), &env.Global)
 	if err != nil {
 		log.Fatalf("Error: %s", err)


### PR DESCRIPTION
The new calendar_test.go (from #173) transitively imports flow/api/serde -> flow/api/env, whose init() calls log.Fatalf when env vars like API_PORT aren't set. 

 Replace the automatic init() in api/env with an explicit Init() called from main(). 