### PR TITLE
test: clean up local regression harness

### DIFF
--- a/regtest/api/auth/email/login.js
+++ b/regtest/api/auth/email/login.js
@@ -27,8 +27,9 @@ export default function(data) {
     group("correct credentials", function() {
       check(login(data.email.email, data.email.password), withLog({
         "status": (r) => r.status == 200,
-        "keys": (r) => keysAre(r.json(), ["token", "user_id"]),
+        "keys": (r) => keysAre(r.json(), ["token", "user_id", "is_new"]),
         "user_id matches registration": (r) => r.json("user_id") == data.email.user_id,
+        "marks existing user": (r) => r.json("is_new") === false,
       }));
     });
   });

--- a/regtest/api/auth/email/register.js
+++ b/regtest/api/auth/email/register.js
@@ -15,7 +15,7 @@ export default function(data) {
     group("empty fields", function() {
       [
         ["", "", "", ""], ["first", "", "", ""], ["", "last", "", ""],
-        ["first", "last", "", ""], ["first", "last", "email", ""], 
+        ["first", "last", "", ""], ["first", "last", "email", ""],
         ["", "", "email", ""], ["", "", "", "pass"],
       ].forEach(cred => check(register(...cred), withLog({
         "status": (r) => r.status == 400,
@@ -34,10 +34,11 @@ export default function(data) {
       }));
     });
 
+    const testRun = `${__VU}-${Date.now()}`;
     const testUser = {
       first: `Test`,
       last:  `User ${__VU}`,
-      email: `test+${__VU}@test.test`,
+      email: `test+${testRun}@test.test`,
       password: `password${__VU}`,
     };
     const res = register(testUser.first, testUser.last, testUser.email, testUser.password);
@@ -45,7 +46,8 @@ export default function(data) {
     group("valid registration", function() {
       check(res, withLog({
         "status": (r) => r.status == 200,
-        "fields": (r) => keysAre(r.json(), ["token", "user_id"]),
+        "fields": (r) => keysAre(r.json(), ["token", "user_id", "is_new"]),
+        "marks new user": (r) => r.json("is_new") === true,
       }));
     });
 

--- a/regtest/api/auth/fb/login.js
+++ b/regtest/api/auth/fb/login.js
@@ -22,12 +22,18 @@ function getAccessToken(number) {
 
 export default function(data) {
   group("facebook login", function() {
+    if (!__ENV.FB_APP_ID || !__ENV.FB_APP_SECRET) {
+      console.log("[*] skipping facebook login: FB_APP_ID and FB_APP_SECRET are not set");
+      return;
+    }
+
     const token = getAccessToken(__VU);
     const first = login(token);
     group("valid token", function() {
       check(first, withLog({
         "status": (r) => r.status == 200,
-        "keys": (r) => keysAre(r.json(), ["token", "user_id"]),
+        "keys": (r) => keysAre(r.json(), ["token", "user_id", "is_new"]),
+        "marks new user": (r) => r.json("is_new") === true,
       }));
     });
     const second = login(token);
@@ -35,6 +41,7 @@ export default function(data) {
       check(second, withLog({
         "status": (r) => r.status == 200,
         "matches first login": (r) => r.json("user_id") == first.json("user_id"),
+        "marks existing user": (r) => r.json("is_new") === false,
       }));
     });
   });

--- a/regtest/graphql/common.js
+++ b/regtest/graphql/common.js
@@ -3,6 +3,6 @@ import { GRAPHQL_URL } from "/src/const.js";
 
 export function graphql(mutation, variables, token) {
   const payload = {query: mutation, variables};
-  const headers = {"Authorization": `Bearer ${token}`};
+  const headers = token ? {"Authorization": `Bearer ${token}`} : {};
   return http.post(GRAPHQL_URL, JSON.stringify(payload), {headers});
 }

--- a/regtest/graphql/user.js
+++ b/regtest/graphql/user.js
@@ -1,5 +1,5 @@
 import { check, group } from "k6";
-import { graphql, AFFECTED_ROWS } from "/src/graphql/common.js";
+import { graphql } from "/src/graphql/common.js";
 import { withLog } from "/src/util.js";
 
 const DELETE_MUTATION = `

--- a/regtest/util.js
+++ b/regtest/util.js
@@ -1,7 +1,7 @@
 import { check, group } from "k6";
 
 export function keysAre(object, keys) {
-  const union = new Set(Object.keys(object), keys);
+  const union = new Set(Object.keys(object).concat(keys));
   return union.size == keys.length;
 }
 

--- a/script/regtest.sh
+++ b/script/regtest.sh
@@ -13,4 +13,4 @@ $PREFIX docker run --rm -i \
   -e GODEBUG=tls13=1 \
   -v "$BACKEND_DIR/regtest":/src:ro \
   --network=host \
-  loadimpact/k6 run --insecure-skip-tls-verify /src/test.js
+  grafana/k6 run --insecure-skip-tls-verify /src/test.js


### PR DESCRIPTION
## Summary

This PR only updates the local k6 regression test harness. It does not change application/runtime behavior.

The goal is to make the local Docker-backed regression suite usable for contributor workflows and to prepare the test harness for a follow-up search PR that adds anonymous GraphQL search coverage.

## Why?

While testing the follow-up course search change against the README public dump and local Docker stack, a few existing regtest issues made the suite noisy or unusable:

- The k6 Docker image was still `loadimpact/k6`, which is deprecated and failed on my Docker setup because it does not have the expected arm64 image support.
- The GraphQL helper always sent an `Authorization: Bearer <token>` header, even when a test intentionally had no token. That blocks anonymous GraphQL endpoint tests, which are needed for public search.
- `keysAre` was not doing what its name suggests. `new Set(Object.keys(object), keys)` ignores the second argument, so the expected-key list was not actually part of the comparison.
- Email auth tests reused the same `test+${__VU}@test.test` address, so rerunning the suite against the same local DB could turn a “valid registration” check into a duplicate-user failure.
- Auth tests expected only `token` and `user_id`, but the current API also returns `is_new`.
- The Facebook auth test assumes `FB_APP_ID` and `FB_APP_SECRET` exist, but `.env.sample` does not define them. In local contributor setups, that test throws before the rest of the suite can be read cleanly.
- `regtest/graphql/user.js` imported `AFFECTED_ROWS`, which is not exported or used.

## Changes

- Switch k6 image in `script/regtest.sh` from `loadimpact/k6` to `grafana/k6`.
- Fix `keysAre` to compare actual and expected keys by unioning both arrays.
- Make the GraphQL helper omit the auth header when no token is passed.
- Remove the unused broken `AFFECTED_ROWS` import.
- Make email registration tests use a timestamped test email so they can be rerun against the same DB.
- Update email/Facebook auth tests to assert the current `is_new` response field.
- Skip Facebook login regtest when `FB_APP_ID` / `FB_APP_SECRET` are not configured.

## Impact

Should not affect production behavior. It only changes files under `regtest/` and `script/regtest.sh`.

The one behavioral change inside the tests is intentional: Facebook login is skipped when local Facebook test credentials are absent. If those env vars are present, the Facebook test still runs.

## Relationship To Follow-Up PR

I have another PR incoming that will change search functionality -- so I intentionally this stuff split out from the course search change.

The follow-up PR adds topic-aware course search and includes a new anonymous GraphQL search regression test. That test depends on two harness fixes from this PR:
- anonymous GraphQL calls must not send an invalid `Authorization` header;
- the k6 image must be runnable in the local Docker setup.

Splitting this first keeps the follow-up search PR focused on product behavior: the Hasura search migration and the search-specific regression tests -- here is the PR FYI: https://github.com/sabdulmajid/uwflow/pull/1 