### PR TITLE
fix(importer): handle UW API rate limiting with retry and inter-request delay

### DIFF
--- a/flow/importer/uw/api/client.go
+++ b/flow/importer/uw/api/client.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
 
 	"flow/common/env"
@@ -15,6 +17,13 @@ const ApiTimeout = time.Second * 10
 
 const (
 	BaseUrlv3 = "https://openapi.data.uwaterloo.ca/v3"
+)
+
+// Retry configuration for 429 responses.
+const (
+	maxRetries     = 5
+	retryBaseDelay = time.Second
+	retryMaxDelay  = 60 * time.Second
 )
 
 type Client struct {
@@ -44,27 +53,79 @@ func (api *Client) do(req *http.Request) (*http.Response, error) {
 	return res, nil
 }
 
+// retryDelay returns the duration to wait before the next retry attempt.
+// It honours the Retry-After response header when present, otherwise uses
+// exponential backoff (base * 2^attempt) with up to 20% random jitter to
+// spread retries if multiple calls hit the limit simultaneously.
+func retryDelay(res *http.Response, attempt int) time.Duration {
+	if res != nil {
+		if val := res.Header.Get("Retry-After"); val != "" {
+			if secs, err := strconv.Atoi(val); err == nil && secs > 0 {
+				return time.Duration(secs) * time.Second
+			}
+		}
+	}
+	// Exponential backoff: 1s, 2s, 4s, 8s, 16s …
+	delay := retryBaseDelay * (1 << uint(attempt))
+	if delay > retryMaxDelay {
+		delay = retryMaxDelay
+	}
+	jitter := time.Duration(rand.Int63n(int64(delay / 5)))
+	return delay + jitter
+}
+
 // Issue a GET to a given UWAPIv3 endpoint and decode the response into dst
 func (api *Client) Getv3(endpoint string, dst interface{}) error {
 	url := fmt.Sprintf("%s/%s", BaseUrlv3, endpoint)
 	log.Printf("GET [v3] %s", url)
 
-	// We do not need to add .WithTimeout here: client.Timeout is respected
-	req, err := http.NewRequestWithContext(api.ctx, "GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("failed to set up request: %w", err)
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		// We do not need to add .WithTimeout here: client.Timeout is respected
+		req, err := http.NewRequestWithContext(api.ctx, "GET", url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to set up request: %w", err)
+		}
+
+		req.Header.Add("X-Api-Key", api.keyv3)
+		res, err := api.do(req)
+
+		// Non-429 errors (including other 4xx/5xx) fail immediately.
+		if err != nil && (res == nil || res.StatusCode != http.StatusTooManyRequests) {
+			if res != nil && res.Body != nil {
+				res.Body.Close()
+			}
+			return fmt.Errorf("http request failed: %w", err)
+		}
+
+		if err == nil {
+			// Success — decode and return.
+			decErr := json.NewDecoder(res.Body).Decode(dst)
+			res.Body.Close()
+			if decErr != nil {
+				return fmt.Errorf("failed to parse JSON: %w", decErr)
+			}
+			return nil
+		}
+
+		// HTTP 429: rate limited.
+		if attempt == maxRetries {
+			return fmt.Errorf("http request failed after %d retries: %w", maxRetries, err)
+		}
+
+		wait := retryDelay(res, attempt)
+		log.Printf("WARNING: rate limited by UW API (429), retrying in %v (attempt %d/%d): %s",
+			wait.Round(time.Millisecond), attempt+1, maxRetries, url)
+
+		if res != nil && res.Body != nil {
+			res.Body.Close()
+		}
+
+		select {
+		case <-api.ctx.Done():
+			return fmt.Errorf("context cancelled while waiting to retry: %w", api.ctx.Err())
+		case <-time.After(wait):
+		}
 	}
 
-	req.Header.Add("X-Api-Key", api.keyv3)
-	res, err := api.do(req)
-	if err != nil {
-		return fmt.Errorf("http request failed: %w", err)
-	}
-	defer res.Body.Close()
-
-	err = json.NewDecoder(res.Body).Decode(dst)
-	if err != nil {
-		return fmt.Errorf("failed to parse JSON: %w", err)
-	}
-	return nil
+	return fmt.Errorf("http request failed: exceeded max retries")
 }

--- a/flow/importer/uw/parts/course/fetch.go
+++ b/flow/importer/uw/parts/course/fetch.go
@@ -3,15 +3,18 @@ package course
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"flow/importer/uw/api"
 	"flow/importer/uw/log"
 )
 
-type empty struct{}
-type semaphore chan []apiClass
-
-const rateLimit = 30
+// classRequestDelay is the minimum pause between consecutive ClassSchedules
+// requests. The UW Open Data API enforces rate limits that return HTTP 429
+// when exceeded. 150ms keeps throughput reasonable while staying well under
+// the observed limit. Tune upward if 429s recur despite the retry logic in
+// api/client.go.
+const classRequestDelay = 150 * time.Millisecond
 
 func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error) {
 	// Fetch course data
@@ -20,48 +23,35 @@ func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error
 		return nil, nil, fmt.Errorf("failed to fetch courses: %w", err)
 	}
 
-	// Fetch class schedules for all returned courses, for upcoming terms
+	// Fetch class schedules for all returned courses, for upcoming terms.
+	// Requests are kept sequential (one at a time) with a small inter-request
+	// delay to avoid triggering API rate limits.
 	var classes []apiClass
-	var numClasses = len(courses) * len(termIds)
-	var numFetched = 0
-
-	sema := make(semaphore, rateLimit)
-	errch := make(chan error, numClasses)
+	numClasses := len(courses) * len(termIds)
+	numFetched := 0
 
 	for _, course := range courses {
 		for _, termId := range termIds {
-			go asyncFetchClass(client, course, termId, sema, errch)
-			numFetched += 1
+			fetched, err := fetchClass(client, &course, termId)
+			numFetched++
 			if numFetched%500 == 0 {
-				log.Warnf("fetched %d/%d courses", numFetched, numClasses)
+				log.Warnf("fetched %d/%d class schedules", numFetched, numClasses)
 			}
 
-			for _, class := range <-sema {
-				class.CourseCode = strings.ToLower(course.Subject + course.Number)
-				classes = append(classes, class)
-			}
-
-			err = <-errch
 			if err != nil {
 				log.Warnf("failed to fetch section with error %s, proceeding anyway", err)
-				continue
+			} else {
+				for _, class := range fetched {
+					class.CourseCode = strings.ToLower(course.Subject + course.Number)
+					classes = append(classes, class)
+				}
 			}
+
+			time.Sleep(classRequestDelay)
 		}
 	}
 
 	return courses, classes, nil
-}
-
-func asyncFetchClass(
-	client *api.Client,
-	course apiCourse,
-	termId int,
-	sema semaphore,
-	errch chan error,
-) {
-	classes, err := fetchClass(client, &course, termId)
-	sema <- classes
-	errch <- err
 }
 
 func fetchClass(client *api.Client, course *apiCourse, termId int) ([]apiClass, error) {
@@ -69,7 +59,7 @@ func fetchClass(client *api.Client, course *apiCourse, termId int) ([]apiClass, 
 	endpoint := fmt.Sprintf("ClassSchedules/%d/%s/%s", termId, course.Subject, course.Number)
 	err := client.Getv3(endpoint, &classes)
 
-	// Many courses returned for each term may not have class schedules and return a 404
+	// Many courses returned for each term may not have class schedules and return a 404.
 	if err != nil && strings.Contains(err.Error(), "404") {
 		return classes, nil
 	}
@@ -89,11 +79,6 @@ func fetchCourses(client *api.Client, termIds []int) ([]apiCourse, error) {
 		}
 		for _, course := range termCourses {
 			courseCode := course.Subject + course.Number
-			if err != nil {
-				log.Warnf("skipping course with missing data")
-				continue
-			}
-
 			if !seenCourse[courseCode] {
 				courses = append(courses, course)
 				seenCourse[courseCode] = true


### PR DESCRIPTION

The UW Open Data API now enforces rate limits, causing HTTP 429 responses that silently dropped data on import runs. Two changes fix this:

- api/client.go: Getv3 now retries up to 5 times on 429, honouring the Retry-After header when present and falling back to exponential backoff (1s→2s→4s→8s→16s + 20% jitter). Non-429 errors still fail immediately. Also fixes a response body leak on non-2xx non-429 responses.

- parts/course/fetch.go: replaces the broken goroutine/semaphore pattern (which was already sequential but with zero delay between requests) with a plain sequential loop + 150ms inter-request pause (~6 req/s). Also removes a dead `if err != nil` check that was always false.

How to Test:
1. `make import-course` and expect some 429
2. Pull this branch, run `make import-course` again and expect it works. 