### PR TITLE
Fix Importer

### DIFF
--- a/flow/importer/uw/api/client.go
+++ b/flow/importer/uw/api/client.go
@@ -56,7 +56,7 @@ func (api *Client) do(req *http.Request) (*http.Response, error) {
 // It honours the Retry-After response header when present, otherwise uses
 // exponential backoff (base * 2^attempt) with up to 20% random jitter to
 // spread retries if multiple calls hit the limit simultaneously.
-func retryDelay(res *http.Response, attempt int) time.Duration {
+func retryDelay(res *http.Response) time.Duration {
 	if res != nil {
 		if val := res.Header.Get("Retry-After"); val != "" {
 			if secs, err := strconv.Atoi(val); err == nil && secs > 0 {
@@ -69,7 +69,7 @@ func retryDelay(res *http.Response, attempt int) time.Duration {
 }
 
 // Issue a GET to a given UWAPIv3 endpoint and decode the response into dst
-func (api *Client) Getv3(endpoint string, dst interface{}) error {
+func (api *Client) Getv3(endpoint string, dst any) error {
 	url := fmt.Sprintf("%s/%s", BaseUrlv3, endpoint)
 	log.Printf("GET [v3] %s", url)
 
@@ -106,7 +106,7 @@ func (api *Client) Getv3(endpoint string, dst interface{}) error {
 			return fmt.Errorf("http request failed after %d retries: %w", maxRetries, err)
 		}
 
-		wait := retryDelay(res, attempt)
+		wait := retryDelay(res)
 		log.Printf("WARNING: rate limited by UW API (429), retrying in %v (attempt %d/%d): %s",
 			wait.Round(time.Millisecond), attempt+1, maxRetries, url)
 

--- a/flow/importer/uw/api/client.go
+++ b/flow/importer/uw/api/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
 	"net/http"
 	"strconv"
 	"time"
@@ -65,13 +64,8 @@ func retryDelay(res *http.Response, attempt int) time.Duration {
 			}
 		}
 	}
-	// Exponential backoff: 1s, 2s, 4s, 8s, 16s …
-	delay := retryBaseDelay * (1 << uint(attempt))
-	if delay > retryMaxDelay {
-		delay = retryMaxDelay
-	}
-	jitter := time.Duration(rand.Int63n(int64(delay / 5)))
-	return delay + jitter
+	// Wait long enough for the 60-second rate limit window to reset.
+	return retryMaxDelay + time.Second
 }
 
 // Issue a GET to a given UWAPIv3 endpoint and decode the response into dst

--- a/flow/importer/uw/api/client.go
+++ b/flow/importer/uw/api/client.go
@@ -12,7 +12,7 @@ import (
 	"flow/common/env"
 )
 
-const ApiTimeout = time.Second * 10
+const ApiTimeout = time.Second * 30
 
 const (
 	BaseUrlv3 = "https://openapi.data.uwaterloo.ca/v3"

--- a/flow/importer/uw/crontab
+++ b/flow/importer/uw/crontab
@@ -1,7 +1,8 @@
 # Redirect stdout and stderr to Docker stdout/stderr respectively
 # Times are in UTC
 
-# Fetch important updates (e.g. courses, sections) every 2 hours on the 20 minute mark
-20 */2 * * * /app/uw hourly >/proc/1/fd/1 2>/proc/1/fd/2
+# Fetch important updates (e.g. courses, sections) once daily at 06:20 UTC
+# (after vacuum at 05:30 UTC; run time is several hours due to API rate limiting at 120 req/min)
+20 6 * * * /app/uw hourly >/proc/1/fd/1 2>/proc/1/fd/2
 # Vacuum daily at 00:30 EST = 05:30 UTC
 30 05 * * * /app/uw vacuum >/proc/1/fd/1 2>/proc/1/fd/2

--- a/flow/importer/uw/parts/course/convert.go
+++ b/flow/importer/uw/parts/course/convert.go
@@ -350,17 +350,62 @@ func convertMeeting(
 		return nil
 	}
 
-	dst.Meetings = append(
-		dst.Meetings,
-		meeting{
-			ClassNumber: apiClass.ClassNumber,
-			TermId:      term.Id,
-			IsCancelled: false,
-			IsClosed:    false,
-			IsTba:       false,
-		},
-	)
-	meeting := &dst.Meetings[len(dst.Meetings)-1]
+	var err error
+	var startSeconds, endSeconds int
+	var startDate, endDate time.Time
+
+	// Handle null/empty times for online async courses
+	// Set them to 12:00 AM (0 seconds) as they have no scheduled meeting times
+	if apiClassSchedule.StartTime == "" || apiClassSchedule.EndTime == "" {
+		startSeconds = 0 // 12:00 AM
+		endSeconds = 0   // 12:00 AM
+	} else {
+		startSeconds, err = util.TimeStringToSeconds(apiClassSchedule.StartTime)
+		if err != nil {
+			return fmt.Errorf("failed to convert time: %w", err)
+		}
+
+		endSeconds, err = util.TimeStringToSeconds(apiClassSchedule.EndTime)
+		if err != nil {
+			return fmt.Errorf("failed to convert time: %w", err)
+		}
+	}
+
+	// Parse dates - these should always be present
+	if apiClassSchedule.StartDate == "" || apiClassSchedule.EndDate == "" {
+		return fmt.Errorf("missing start or end date")
+	}
+
+	startDate, err = time.Parse(util.ApiV3DateLayout, apiClassSchedule.StartDate)
+	if err != nil {
+		return fmt.Errorf("failed to convert date: %w", err)
+	}
+
+	endDate, err = time.Parse(util.ApiV3DateLayout, apiClassSchedule.EndDate)
+	if err != nil {
+		return fmt.Errorf("failed to convert date: %w", err)
+	}
+
+	var days []string
+	if apiClassSchedule.Weekdays != nil {
+		days = util.ParseWeekdayString(*apiClassSchedule.Weekdays)
+	} else {
+		days = make([]string, 0)
+	}
+
+	// Create meeting with all fields populated
+	newMeeting := meeting{
+		ClassNumber:  apiClass.ClassNumber,
+		TermId:       term.Id,
+		StartSeconds: pgtype.Int4{Int32: int32(startSeconds), Valid: true},
+		EndSeconds:   pgtype.Int4{Int32: int32(endSeconds), Valid: true},
+		StartDate:    startDate,
+		EndDate:      endDate,
+		Days:         days,
+		IsCancelled:  false,
+		IsClosed:     false,
+		IsTba:        false,
+	}
 
 	if len(apiClass.Instructors) > 0 {
 		if dst.Profs == nil {
@@ -376,7 +421,7 @@ func convertMeeting(
 		name := fmt.Sprintf("%s %s", instructor.FirstName, instructor.LastName)
 		code := util.ProfNameToCode(name)
 		dst.Profs[code] = name
-		meeting.ProfCode = pgtype.Text{String: code, Valid: true}
+		newMeeting.ProfCode = pgtype.Text{String: code, Valid: true}
 	}
 
 	if apiClassSchedule.Location != nil {
@@ -386,37 +431,9 @@ func convertMeeting(
 		if err == nil {
 			location = "Online"
 		}
-		meeting.Location = pgtype.Text{String: location, Valid: true}
+		newMeeting.Location = pgtype.Text{String: location, Valid: true}
 	}
 
-	var err error
-	startSeconds, err := util.TimeStringToSeconds(apiClassSchedule.StartTime)
-	if err != nil {
-		return fmt.Errorf("failed to convert time: %w", err)
-	}
-	meeting.StartSeconds = pgtype.Int4{Int32: int32(startSeconds), Valid: true}
-
-	endSeconds, err := util.TimeStringToSeconds(apiClassSchedule.EndTime)
-	if err != nil {
-		return fmt.Errorf("failed to convert time: %w", err)
-	}
-	meeting.EndSeconds = pgtype.Int4{Int32: int32(endSeconds), Valid: true}
-
-	meeting.StartDate, err = time.Parse(util.ApiV3DateLayout, apiClassSchedule.StartDate)
-	if err != nil {
-		return fmt.Errorf("failed to convert date: %w", err)
-	}
-
-	meeting.EndDate, err = time.Parse(util.ApiV3DateLayout, apiClassSchedule.EndDate)
-	if err != nil {
-		return fmt.Errorf("failed to convert date: %w", err)
-	}
-
-	if apiClassSchedule.Weekdays != nil {
-		meeting.Days = util.ParseWeekdayString(*apiClassSchedule.Weekdays)
-	} else {
-		meeting.Days = make([]string, 0)
-	}
-
+	dst.Meetings = append(dst.Meetings, newMeeting)
 	return nil
 }

--- a/flow/importer/uw/parts/course/fetch.go
+++ b/flow/importer/uw/parts/course/fetch.go
@@ -10,11 +10,10 @@ import (
 )
 
 // classRequestDelay is the minimum pause between consecutive ClassSchedules
-// requests. The UW Open Data API enforces rate limits that return HTTP 429
-// when exceeded. 150ms keeps throughput reasonable while staying well under
-// the observed limit. Tune upward if 429s recur despite the retry logic in
-// api/client.go.
-const classRequestDelay = 150 * time.Millisecond
+// requests. The UW Open Data API enforces a limit of 120 req/min (0.5s/req).
+// 550ms gives ~109 req/min, leaving headroom for course-list calls that also
+// count against the same quota.
+const classRequestDelay = 550 * time.Millisecond
 
 func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error) {
 	// Fetch course data

--- a/flow/importer/uw/parts/course/fetch.go
+++ b/flow/importer/uw/parts/course/fetch.go
@@ -30,6 +30,10 @@ func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error
 	numFetched := 0
 
 	for _, course := range courses {
+		// DEBUG: only import PMATH 351 to test end-to-end
+		if course.Subject != "PMATH" || course.Number != "351" {
+			continue
+		}
 		for _, termId := range termIds {
 			fetched, err := fetchClass(client, &course, termId)
 			numFetched++
@@ -55,7 +59,7 @@ func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error
 
 func fetchClass(client *api.Client, course *apiCourse, termId int) ([]apiClass, error) {
 	var classes []apiClass
-	endpoint := fmt.Sprintf("ClassSchedules/%d/%s/%s", termId, course.Subject, course.Number)
+	endpoint := fmt.Sprintf("ClassSchedules/%d/%s", termId, course.CourseId)
 	err := client.Getv3(endpoint, &classes)
 
 	// Many courses returned for each term may not have class schedules and return a 404.

--- a/flow/importer/uw/parts/course/fetch.go
+++ b/flow/importer/uw/parts/course/fetch.go
@@ -30,10 +30,6 @@ func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error
 	numFetched := 0
 
 	for _, course := range courses {
-		// DEBUG: only import PMATH 351 to test end-to-end
-		if course.Subject != "PMATH" || course.Number != "351" {
-			continue
-		}
 		for _, termId := range termIds {
 			fetched, err := fetchClass(client, &course, termId)
 			numFetched++

--- a/flow/importer/uw/parts/course/struct.go
+++ b/flow/importer/uw/parts/course/struct.go
@@ -64,6 +64,7 @@ type antireq struct {
 }
 
 type apiCourse struct {
+	CourseId     string  `json:"courseId"`
 	Subject      string  `json:"subjectCode"`
 	Number       string  `json:"catalogNumber"`
 	Name         string  `json:"title"`


### PR DESCRIPTION
## Description
A lot of things about importer broke recently, mainly due to changes from the data provider: 
1. They revoked our API key on prod :( 
2. A new rate limiting of 120 requests / min is introduced: https://uwaterloo.atlassian.net/wiki/spaces/UWAPI/blog/2026/01/23/44869681282/Open+Data+API+Functional+Changes, making a lot of requests get 429 
3. Some requests take > 10 sec to respond 
4. The class schedule endpoint changed from `ClassSchedules/{termId}/{subject}/{number}` to `ClassSchedules/{termId}/{courseId}`, making us fail to fetch class times. 
5. Online courses now return empty start and end times, rather than 12AM as before, making the current code fail to parse times and resulting in 0 DB insertions. 

## What this PR does:
1. Introduce 550ms sleep time between two requests, this makes ~109 requests / min
2. Add a retry after 61s if 429 is encountered
3. Increase API timeout limit from 10s to 30s
4. Use the new correct endpoint
6. Reduce the frequency of cron job from every 2 hours to every day, as the import job cannot finish in 2 hours now. 
7. Add 12AM start and end time accordingly.

## What will change
Now we should expect the importer to take several hours to finish fetching data. 

## How to test: 
1. Start services locally
2. Find an in-person course in Spring 2026, with meeting times already published in `https://classes.uwaterloo.ca/`, for example, ECON 201: https://classes.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=1265&subject=ECON&cournum=201
3. Expect your frontend not rendering meeting times:
<img width="1224" height="334" alt="image" src="https://github.com/user-attachments/assets/439a32b4-f1e4-4fc7-a65b-fa92c06e76fb" />
8. Add some filtering in importer for testing, as we don't want to run the full importer which will take hours. In `flow/importer/uw/parts/course/fetch.go` after line 32, add:

```go
		if course.Subject != "ECON" || course.Number != "201" {
			continue
		}
```

9. Run `make import-course` 
10. Expect meeting times rendered in frontend:
<img width="1256" height="333" alt="image" src="https://github.com/user-attachments/assets/02008283-0e23-4c15-82a8-ac76febfb084" />
