### PR TITLE
feat(staging): single-box EC2 Terraform deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ flow/api/tmp
 flow/email/tmp
 # PG Dump
 *.dump
+# Terraform
+terraform.tfvars
+*.tfstate*
+.terraform/
+.terraform.lock.hcl
+# TLS certs/keys — never commit
+*.pem
+

--- a/staging/.gitignore
+++ b/staging/.gitignore
@@ -1,4 +1,0 @@
-terraform.tfvars
-*.tfstate*
-.terraform/
-.terraform.lock.hcl

--- a/staging/.gitignore
+++ b/staging/.gitignore
@@ -1,0 +1,4 @@
+terraform.tfvars
+*.tfstate*
+.terraform/
+.terraform.lock.hcl

--- a/staging/README.md
+++ b/staging/README.md
@@ -1,0 +1,189 @@
+# uwflow-terraform
+
+Cheap single-box AWS deploy of the [UWFlow](https://github.com/UWFlow/uwflow)
+docker-compose stack for **staging**. Target cost: **~$19.50/mo** running,
+**~$0.80/mo** when stopped (t3.small + auto-assigned public IPv4 + 10 GiB gp3).
+
+This is one EC2 instance running all six containers (postgres, hasura, api,
+uw, email, frontend/nginx). Not for production — no RDS, no ALB, no managed
+TLS, no autoscaling. See `main.tf` for `TODO` markers where each of those
+would be the next upgrade.
+
+## Files
+
+```
+.
+├── main.tf                       # SG, IAM, AMI, EC2
+├── variables.tf                  # inputs (incl. sensitive app_env map)
+├── outputs.tf                    # public_ip, ssh/ssm one-liners, cost
+├── providers.tf                  # AWS provider + default tags
+├── versions.tf                   # terraform >= 1.6, aws ~> 5
+├── templates/
+│   └── user_data.sh.tftpl        # cloud-init: docker, clone, .env, certs, up
+└── README.md
+```
+
+## Quick start
+
+```bash
+cp terraform.tfvars.example terraform.tfvars   # then edit (see below)
+terraform init
+terraform apply
+```
+
+Outputs include the public IP. **Manually create an A record**
+`<domain_name> -> <public_ip>` at your DNS provider — Terraform does not
+touch Route53 here. ⚠️ The IP is auto-assigned, not Elastic — it changes
+every time you stop/start or replace the instance, and you'll need to
+refresh the A record.
+
+SSH (key pair required):
+
+```bash
+ssh -i ~/.ssh/<key_name>.pem ubuntu@<public_ip>
+```
+
+SSM Session Manager (no inbound SSH needed, works even with port 22 closed):
+
+```bash
+aws ssm start-session --target <instance-id>
+```
+
+## Sample `terraform.tfvars`
+
+```hcl
+aws_region       = "us-east-1"
+instance_type    = "t3.small"          # bump to t3.medium (~$30/mo) if RAM-tight
+key_name         = "my-ec2-keypair"
+domain_name      = "staging.uwflow.com"
+allowed_ssh_cidr = "1.2.3.4/32"        # your IP — don't leave as 0.0.0.0/0
+
+app_env = {
+  # --- API ---
+  API_PORT                         = "8081"
+  DOMAIN                           = "staging.uwflow.com"
+  RUN_MODE                         = "staging"
+
+  # --- Hasura ---
+  HASURA_GRAPHQL_ADMIN_SECRET      = "CHANGE_ME_LONG_RANDOM"
+  HASURA_GRAPHQL_UNAUTHORIZED_ROLE = "public"
+  HASURA_GRAPHQL_JWT_KEY           = "CHANGE_ME_LONG_RANDOM"
+  HASURA_PORT                      = "8080"
+
+  # --- Sentry ---
+  SENTRY_DSN                       = ""
+  SENTRY_TRACES_SAMPLE_RATE        = "0.1"
+  SENTRY_ERROR_SAMPLE_RATE         = "1.0"
+
+  # --- nginx ---
+  NGINX_HTTP_PORT                  = "80"
+  NGINX_HTTPS_PORT                 = "443"
+
+  # --- Postgres ---
+  POSTGRES_DB                      = "flow"
+  POSTGRES_HOST                    = "postgres"
+  POSTGRES_PASSWORD                = "CHANGE_ME"
+  POSTGRES_PORT                    = "5432"
+  POSTGRES_USER                    = "postgres"
+
+  # --- UW open data API ---
+  UW_API_KEY_V3                    = "CHANGE_ME"
+
+  # --- Email ---
+  SMTP_SERVER                      = "smtp.sendgrid.net"
+  SMTP_PORT                        = "587"
+  SMTP_FROM                        = "noreply@staging.uwflow.com"
+  SMTP_USERNAME                    = "apikey"
+  SMTP_PASSWORD                    = "CHANGE_ME"
+}
+```
+
+`app_env` is marked `sensitive` — values won't show in plan/apply output —
+but **don't commit `terraform.tfvars`**. Either keep it local, use a
+secrets manager, or set `TF_VAR_app_env` from the shell.
+
+## Seeding the database
+
+The Postgres container writes to a Docker named volume on the root EBS
+disk. `terraform destroy` (or any change that triggers instance
+replacement) **wipes the DB**. That's the trade-off for staying at $17/mo.
+
+To seed from a `pg_dump`:
+
+```bash
+# 1. copy the dump to the instance
+scp -i ~/.ssh/<key>.pem flow.dump ubuntu@<public_ip>:/home/ubuntu/
+
+# 2. restore into the postgres container
+ssh -i ~/.ssh/<key>.pem ubuntu@<public_ip> \
+  'docker exec -i postgres pg_restore -U postgres -d flow --clean --if-exists' \
+  < /home/ubuntu/flow.dump
+```
+
+For a plain SQL dump use `psql -U postgres -d flow` in place of
+`pg_restore`.
+
+## Stopping the instance to save more
+
+When you're not actively using staging, stop the instance:
+
+```bash
+aws ec2 stop-instances --instance-ids <instance-id>
+```
+
+Stopped t3.small costs **$0** for compute. You still pay for the 10 GiB
+gp3 root volume (~$0.80/mo). The auto-assigned public IP is released
+when the instance stops — you get a different one when you start it
+back up, so **the A record needs to be updated** after each restart.
+The Docker volumes persist on the root disk; `docker compose up -d` on
+start brings everything back without re-seeding.
+
+## TLS
+
+`user_data.sh.tftpl` drops a self-signed cert into `./.ssl/` so nginx can
+start on first boot. Browsers will warn. Once DNS is pointed at the EIP,
+swap in a real cert — easiest path is certbot in standalone mode (stop
+nginx briefly, issue the cert, copy into `.ssl/`, restart). See the TODO
+in the template.
+
+## Importer cron
+
+`/etc/cron.d/uwflow-importer` is installed by cloud-init:
+
+```
+0 * * * * root docker exec uw /app/uw hourly >> /var/log/uwflow-importer.log 2>&1
+0 3 * * * root docker exec uw /app/uw vacuum >> /var/log/uwflow-importer.log 2>&1
+```
+
+Tail it with `ssh ... 'sudo tail -f /var/log/uwflow-importer.log'`.
+
+## Cost breakdown (on-demand)
+
+| Item                                | Monthly |
+| ----------------------------------- | ------- |
+| t3.small (730 hr)                   | ~$15.18 |
+| 10 GiB gp3 root volume              | ~$0.80  |
+| Public IPv4 (auto-assigned, attached) | ~$3.60  |
+| **Total, running**                  | **~$19.50** |
+| **Total, stopped 24/7**             | ~$0.80  |
+
+Note: AWS charges for all public IPv4s since Feb 2024, so swapping the
+auto-assigned IP for an Elastic IP doesn't change the running cost —
+the trade-off is stable address vs. extra resource to manage.
+
+Detailed CloudWatch is disabled (`monitoring = false`). Bandwidth is
+metered separately but negligible for a staging box.
+
+## What's intentionally missing (and roughly what each upgrade costs)
+
+- **Route53** — manual A record instead (~$0.50/mo to automate).
+- **ACM / ALB / managed TLS** — self-signed + TODO for certbot (ALB adds ~$16/mo).
+- **RDS** — Postgres in a Docker volume on root (RDS db.t4g.micro ~$13/mo).
+- **Separate data EBS** — Docker volume on root, lost on destroy (~$2/mo per 25 GiB).
+- **Autoscaling, multi-AZ, modules** — out of scope for one cheap box.
+
+## Remote state
+
+Local state by default. A commented `backend "s3"` stub lives in
+`versions.tf` — uncomment and fill in once you've created the bucket +
+DynamoDB lock table.

--- a/staging/README.md
+++ b/staging/README.md
@@ -1,8 +1,7 @@
 # uwflow-terraform
 
 Cheap single-box AWS deploy of the [UWFlow](https://github.com/UWFlow/uwflow)
-docker-compose stack for **staging**. Target cost: **~$19.50/mo** running,
-**~$0.80/mo** when stopped (t3.small + auto-assigned public IPv4 + 10 GiB gp3).
+docker-compose stack for **staging**.
 
 This is one EC2 instance running all six containers (postgres, hasura, api,
 uw, email, frontend/nginx). Not for production — no RDS, no ALB, no managed
@@ -15,7 +14,7 @@ would be the next upgrade.
 .
 ├── main.tf                       # SG, IAM, AMI, EC2
 ├── variables.tf                  # inputs (incl. sensitive app_env map)
-├── outputs.tf                    # public_ip, ssh/ssm one-liners, cost
+├── outputs.tf                    # public_ip, ssh/ssm one-liners
 ├── providers.tf                  # AWS provider + default tags
 ├── versions.tf                   # terraform >= 1.6, aws ~> 5
 ├── templates/
@@ -23,11 +22,59 @@ would be the next upgrade.
 └── README.md
 ```
 
+## Prerequisites
+
+### 1. AWS credentials (`aws configure`)
+
+Install the AWS CLI (`brew install awscli` on macOS), then create an IAM
+user with programmatic access (or use SSO) and run:
+
+```bash
+aws configure
+```
+
+You'll be prompted for four values:
+
+| Prompt                    | Example          | Notes                                |
+| ------------------------- | ---------------- | ------------------------------------ |
+| AWS Access Key ID         | `AKIA...`        | IAM → Users → Security credentials   |
+| AWS Secret Access Key     | `wJalr...`       | Shown once at key creation           |
+| Default region name       | `us-east-2`      | Must match `var.aws_region`          |
+| Default output format     | `json`           | Any value is fine                    |
+
+This writes `~/.aws/credentials` and `~/.aws/config`, which both Terraform
+and `aws` CLI commands pick up automatically. Verify with:
+
+I'm lazy and created an IAM role with AdminstratorAccess, and got the Access Key ID
+and Secret Access Key as such. 
+
+
+### 2. EC2 key pair
+
+You need an SSH key pair in EC2 to SSH into the box. Create one via the
+CLI (the only way to get the private key out — the console **doesn't let
+you re-download** an existing key):
+
+```bash
+KEY_NAME=uwflow-staging                           
+aws ec2 create-key-pair \
+  --key-name "$KEY_NAME" \
+  --key-type ed25519 \
+  --query 'KeyMaterial' \
+  --output text \
+  > ~/.ssh/"$KEY_NAME".pem
+chmod 400 ~/.ssh/"$KEY_NAME".pem
+```
+
+Then set `key_name = "uwflow-staging"` in `terraform.tfvars`.
+
+
 ## Quick start
 
 ```bash
-cp terraform.tfvars.example terraform.tfvars   # then edit (see below)
+cp terraform.tfvars.example terraform.tfvars 
 terraform init
+terraform plan
 terraform apply
 ```
 
@@ -43,65 +90,6 @@ SSH (key pair required):
 ssh -i ~/.ssh/<key_name>.pem ubuntu@<public_ip>
 ```
 
-SSM Session Manager (no inbound SSH needed, works even with port 22 closed):
-
-```bash
-aws ssm start-session --target <instance-id>
-```
-
-## Sample `terraform.tfvars`
-
-```hcl
-aws_region       = "us-east-1"
-instance_type    = "t3.small"          # bump to t3.medium (~$30/mo) if RAM-tight
-key_name         = "my-ec2-keypair"
-domain_name      = "staging.uwflow.com"
-allowed_ssh_cidr = "1.2.3.4/32"        # your IP — don't leave as 0.0.0.0/0
-
-app_env = {
-  # --- API ---
-  API_PORT                         = "8081"
-  DOMAIN                           = "staging.uwflow.com"
-  RUN_MODE                         = "staging"
-
-  # --- Hasura ---
-  HASURA_GRAPHQL_ADMIN_SECRET      = "CHANGE_ME_LONG_RANDOM"
-  HASURA_GRAPHQL_UNAUTHORIZED_ROLE = "public"
-  HASURA_GRAPHQL_JWT_KEY           = "CHANGE_ME_LONG_RANDOM"
-  HASURA_PORT                      = "8080"
-
-  # --- Sentry ---
-  SENTRY_DSN                       = ""
-  SENTRY_TRACES_SAMPLE_RATE        = "0.1"
-  SENTRY_ERROR_SAMPLE_RATE         = "1.0"
-
-  # --- nginx ---
-  NGINX_HTTP_PORT                  = "80"
-  NGINX_HTTPS_PORT                 = "443"
-
-  # --- Postgres ---
-  POSTGRES_DB                      = "flow"
-  POSTGRES_HOST                    = "postgres"
-  POSTGRES_PASSWORD                = "CHANGE_ME"
-  POSTGRES_PORT                    = "5432"
-  POSTGRES_USER                    = "postgres"
-
-  # --- UW open data API ---
-  UW_API_KEY_V3                    = "CHANGE_ME"
-
-  # --- Email ---
-  SMTP_SERVER                      = "smtp.sendgrid.net"
-  SMTP_PORT                        = "587"
-  SMTP_FROM                        = "noreply@staging.uwflow.com"
-  SMTP_USERNAME                    = "apikey"
-  SMTP_PASSWORD                    = "CHANGE_ME"
-}
-```
-
-`app_env` is marked `sensitive` — values won't show in plan/apply output —
-but **don't commit `terraform.tfvars`**. Either keep it local, use a
-secrets manager, or set `TF_VAR_app_env` from the shell.
-
 ## Seeding the database
 
 The Postgres container writes to a Docker named volume on the root EBS
@@ -112,7 +100,7 @@ To seed from a `pg_dump`:
 
 ```bash
 # 1. copy the dump to the instance
-scp -i ~/.ssh/<key>.pem flow.dump ubuntu@<public_ip>:/home/ubuntu/
+scp -i ~/.ssh/<key>.pem ../uwflow/XXX-XX-XX-pg-latest.pgdump ubuntu@<public_ip>:/home/ubuntu/
 
 # 2. restore into the postgres container
 ssh -i ~/.ssh/<key>.pem ubuntu@<public_ip> \
@@ -145,45 +133,3 @@ start on first boot. Browsers will warn. Once DNS is pointed at the EIP,
 swap in a real cert — easiest path is certbot in standalone mode (stop
 nginx briefly, issue the cert, copy into `.ssl/`, restart). See the TODO
 in the template.
-
-## Importer cron
-
-`/etc/cron.d/uwflow-importer` is installed by cloud-init:
-
-```
-0 * * * * root docker exec uw /app/uw hourly >> /var/log/uwflow-importer.log 2>&1
-0 3 * * * root docker exec uw /app/uw vacuum >> /var/log/uwflow-importer.log 2>&1
-```
-
-Tail it with `ssh ... 'sudo tail -f /var/log/uwflow-importer.log'`.
-
-## Cost breakdown (on-demand)
-
-| Item                                | Monthly |
-| ----------------------------------- | ------- |
-| t3.small (730 hr)                   | ~$15.18 |
-| 10 GiB gp3 root volume              | ~$0.80  |
-| Public IPv4 (auto-assigned, attached) | ~$3.60  |
-| **Total, running**                  | **~$19.50** |
-| **Total, stopped 24/7**             | ~$0.80  |
-
-Note: AWS charges for all public IPv4s since Feb 2024, so swapping the
-auto-assigned IP for an Elastic IP doesn't change the running cost —
-the trade-off is stable address vs. extra resource to manage.
-
-Detailed CloudWatch is disabled (`monitoring = false`). Bandwidth is
-metered separately but negligible for a staging box.
-
-## What's intentionally missing (and roughly what each upgrade costs)
-
-- **Route53** — manual A record instead (~$0.50/mo to automate).
-- **ACM / ALB / managed TLS** — self-signed + TODO for certbot (ALB adds ~$16/mo).
-- **RDS** — Postgres in a Docker volume on root (RDS db.t4g.micro ~$13/mo).
-- **Separate data EBS** — Docker volume on root, lost on destroy (~$2/mo per 25 GiB).
-- **Autoscaling, multi-AZ, modules** — out of scope for one cheap box.
-
-## Remote state
-
-Local state by default. A commented `backend "s3"` stub lives in
-`versions.tf` — uncomment and fill in once you've created the bucket +
-DynamoDB lock table.

--- a/staging/main.tf
+++ b/staging/main.tf
@@ -1,13 +1,13 @@
 locals {
   name = "uwflow-staging"
 
-  # Rough monthly cost on-demand pricing.
-  # t3.small:          ~$15.18
-  # Public IPv4:       ~$3.60  (AWS charges for ALL public IPs since Feb 2024)
-  # 10 GiB gp3:        ~$0.80  (3000 IOPS / 125 MB/s baseline included)
-  # Data transfer, SSM, CloudWatch basic metrics: negligible at this scale.
-  # Stopped: just ~$0.80/mo (disk only — auto-assigned IP released on stop).
-  estimated_monthly_cost = "~$19.50/mo running, ~$0.80/mo stopped: t3.small $15 + public IPv4 $3.6 + 10GB gp3 $0.8"
+  # Resolve cert/key paths against the module dir so they're stable no matter
+  # which directory terraform is invoked from. Absolute paths pass through.
+  # path.module is "" for root modules in modern terraform, so coalesce to "."
+  # to avoid producing a bogus "/cert.pem".
+  module_dir    = coalesce(path.module, ".")
+  ssl_cert_file = var.ssl_cert_path == "" ? "" : (startswith(var.ssl_cert_path, "/") ? var.ssl_cert_path : "${local.module_dir}/${var.ssl_cert_path}")
+  ssl_key_file  = var.ssl_key_path == "" ? "" : (startswith(var.ssl_key_path, "/") ? var.ssl_key_path : "${local.module_dir}/${var.ssl_key_path}")
 }
 
 # ---------------------------------------------------------------------------
@@ -56,7 +56,7 @@ data "aws_ami" "ubuntu" {
 
 resource "aws_security_group" "app" {
   name        = "${local.name}-sg"
-  description = "uwflow staging: SSH from allowed CIDR, HTTP/HTTPS from anywhere"
+  description = "uwflow staging: SSH/HTTP/HTTPS from anywhere"
   vpc_id      = data.aws_vpc.default.id
 
   ingress {
@@ -64,7 +64,7 @@ resource "aws_security_group" "app" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = [var.allowed_ssh_cidr]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
@@ -161,6 +161,8 @@ resource "aws_instance" "app" {
   user_data = templatefile("${path.module}/templates/user_data.sh.tftpl", {
     domain_name = var.domain_name
     app_env     = var.app_env
+    ssl_cert    = local.ssl_cert_file != "" ? file(local.ssl_cert_file) : ""
+    ssl_key     = local.ssl_key_file != "" ? file(local.ssl_key_file) : ""
   })
 
   # Re-run cloud-init if the rendered user_data changes (e.g. .env update).

--- a/staging/main.tf
+++ b/staging/main.tf
@@ -1,0 +1,187 @@
+locals {
+  name = "uwflow-staging"
+
+  # Rough monthly cost on-demand pricing.
+  # t3.small:          ~$15.18
+  # Public IPv4:       ~$3.60  (AWS charges for ALL public IPs since Feb 2024)
+  # 10 GiB gp3:        ~$0.80  (3000 IOPS / 125 MB/s baseline included)
+  # Data transfer, SSM, CloudWatch basic metrics: negligible at this scale.
+  # Stopped: just ~$0.80/mo (disk only — auto-assigned IP released on stop).
+  estimated_monthly_cost = "~$19.50/mo running, ~$0.80/mo stopped: t3.small $15 + public IPv4 $3.6 + 10GB gp3 $0.8"
+}
+
+# ---------------------------------------------------------------------------
+# Networking — default VPC / subnet. Cheapest possible: no NAT, no ALB.
+# ---------------------------------------------------------------------------
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# AMI — latest Ubuntu 22.04 LTS (amd64). neuwflow/* images are built on
+# CircleCI's amd64 machine executor, so do NOT switch to t4g/ARM.
+# ---------------------------------------------------------------------------
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Security group — 22 (restricted), 80, 443.
+# ---------------------------------------------------------------------------
+
+resource "aws_security_group" "app" {
+  name        = "${local.name}-sg"
+  description = "uwflow staging: SSH from allowed CIDR, HTTP/HTTPS from anywhere"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_ssh_cidr]
+  }
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name}-sg"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# IAM — SSM only, so we can use Session Manager without a bastion.
+# TODO: add CloudWatch Agent policy if/when we want app log shipping.
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "instance" {
+  name               = "${local.name}-role"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name = "${local.name}-profile"
+  role = aws_iam_role.instance.name
+}
+
+# ---------------------------------------------------------------------------
+# EC2 instance — single box, root volume only. Postgres data lives in a
+# Docker named volume on the root disk; `terraform destroy` wipes the DB,
+# which is acceptable for staging (re-seed from a pg_dump — see README).
+# TODO: for prod, move Postgres to RDS or a separate encrypted EBS volume
+# with a lifecycle prevent_destroy.
+# ---------------------------------------------------------------------------
+
+resource "aws_instance" "app" {
+  ami                  = data.aws_ami.ubuntu.id
+  instance_type        = var.instance_type
+  key_name             = var.key_name
+  subnet_id            = tolist(data.aws_subnets.default.ids)[0]
+  iam_instance_profile = aws_iam_instance_profile.instance.name
+
+  vpc_security_group_ids = [aws_security_group.app.id]
+
+  # Cost-saving: skip detailed (1-min) CloudWatch metrics.
+  monitoring = false
+
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 10 
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required" # IMDSv2 only
+  }
+
+  user_data = templatefile("${path.module}/templates/user_data.sh.tftpl", {
+    domain_name = var.domain_name
+    app_env     = var.app_env
+  })
+
+  # Re-run cloud-init if the rendered user_data changes (e.g. .env update).
+  # Note: this REPLACES the instance, which wipes the Postgres docker volume.
+  # Comment this out if you want to edit .env in place on the running box.
+  user_data_replace_on_change = true
+
+  tags = {
+    Name = local.name
+  }
+}
+
+# No Elastic IP — the instance uses the auto-assigned public IP from its
+# default subnet. The IP changes on stop/start (and on instance replacement),
+# so you'll need to refresh the DNS A record each time the instance restarts.
+# Add an aws_eip + aws_eip_association if you want a stable address.
+
+# TODO (next upgrades, in rough cost order):
+#   - Elastic IP for stable address across stop/start       (~$0/mo running, $3.60/mo stopped)
+#   - Route53 hosted zone + A record for domain_name        (~$0.50/mo)
+#   - ACM cert + certbot/cron OR ALB+ACM termination        (ALB ~$16/mo)
+#   - RDS db.t4g.micro for Postgres                         (~$13/mo)
+#   - Separate EBS volume for /var/lib/docker/volumes       (~$2/mo per 25GB)
+#   - CloudWatch Agent for app log shipping

--- a/staging/outputs.tf
+++ b/staging/outputs.tf
@@ -5,7 +5,7 @@ output "public_ip" {
 
 output "public_dns" {
   description = "AWS-assigned public DNS of the instance."
-  value       = aws_instance.app.public_dns
+  value       = "https://${aws_instance.app.public_dns}"
 }
 
 output "ssh_command" {
@@ -16,11 +16,6 @@ output "ssh_command" {
 output "ssm_command" {
   description = "Open a shell via SSM Session Manager (no SSH key, no inbound port needed). Requires AWS CLI + session-manager-plugin."
   value       = "aws ssm start-session --region ${var.aws_region} --target ${aws_instance.app.id}"
-}
-
-output "estimated_monthly_cost" {
-  description = "Back-of-envelope monthly cost, on-demand."
-  value       = local.estimated_monthly_cost
 }
 
 output "dns_reminder" {

--- a/staging/outputs.tf
+++ b/staging/outputs.tf
@@ -1,0 +1,29 @@
+output "public_ip" {
+  description = "Auto-assigned public IP. Changes on stop/start and on instance replacement."
+  value       = aws_instance.app.public_ip
+}
+
+output "public_dns" {
+  description = "AWS-assigned public DNS of the instance."
+  value       = aws_instance.app.public_dns
+}
+
+output "ssh_command" {
+  description = "SSH one-liner using the configured key pair."
+  value       = "ssh -i ~/.ssh/${var.key_name}.pem ubuntu@${aws_instance.app.public_ip}"
+}
+
+output "ssm_command" {
+  description = "Open a shell via SSM Session Manager (no SSH key, no inbound port needed). Requires AWS CLI + session-manager-plugin."
+  value       = "aws ssm start-session --region ${var.aws_region} --target ${aws_instance.app.id}"
+}
+
+output "estimated_monthly_cost" {
+  description = "Back-of-envelope monthly cost, on-demand."
+  value       = local.estimated_monthly_cost
+}
+
+output "dns_reminder" {
+  description = "Manual DNS step. NOTE: the IP changes on stop/start — update the A record each time you restart the instance."
+  value       = "Create an A record: ${var.domain_name} -> ${aws_instance.app.public_ip}"
+}

--- a/staging/providers.tf
+++ b/staging/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "uwflow"
+      Environment = "staging"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/staging/templates/user_data.sh.tftpl
+++ b/staging/templates/user_data.sh.tftpl
@@ -1,0 +1,79 @@
+#!/bin/bash
+# cloud-init for uwflow staging single-box deploy.
+# Runs once on first boot. Logs to /var/log/cloud-init-output.log.
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+# ---------------------------------------------------------------------------
+# Packages
+# ---------------------------------------------------------------------------
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y \
+  ca-certificates \
+  curl \
+  git \
+  make \
+  openssl \
+  docker.io
+
+systemctl enable --now docker
+usermod -aG docker ubuntu
+
+# Compose v2 as a standalone binary, exposed as `docker-compose` (hyphen)
+# so existing Makefiles/scripts that call v1 syntax keep working.
+# v1 (1.29.2) crashes on `KeyError: ContainerConfig` with modern BuildKit images.
+COMPOSE_VERSION=v2.29.7
+curl -fsSL -o /usr/local/bin/docker-compose \
+  "https://github.com/docker/compose/releases/download/$${COMPOSE_VERSION}/docker-compose-linux-x86_64"
+chmod +x /usr/local/bin/docker-compose
+
+# ---------------------------------------------------------------------------
+# Clone the app
+# ---------------------------------------------------------------------------
+APP_DIR=/home/ubuntu/uwflow
+if [ ! -d "$APP_DIR/.git" ]; then
+  sudo -u ubuntu git clone --branch main --depth 1 \
+    https://github.com/UWFlow/uwflow.git "$APP_DIR"
+fi
+chown -R ubuntu:ubuntu "$APP_DIR"
+
+# ---------------------------------------------------------------------------
+# Render .env from the app_env Terraform variable.
+# KEY=VALUE per line, no quoting (compose reads it as-is).
+# Secrets stay on the box; never commit the rendered file.
+# ---------------------------------------------------------------------------
+ENV_FILE="$APP_DIR/.env"
+cat > "$ENV_FILE" <<'UWFLOW_ENV_EOF'
+%{ for k, v in app_env ~}
+${k}=${v}
+%{ endfor ~}
+UWFLOW_ENV_EOF
+chown ubuntu:ubuntu "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+# ---------------------------------------------------------------------------
+# Self-signed TLS cert so nginx can start.
+# TODO: replace with certbot once DNS is pointed at the EIP, e.g.
+#   docker run --rm -v "$APP_DIR/.ssl:/etc/letsencrypt" certbot/certbot \
+#     certonly --standalone -d ${domain_name} ...
+# ---------------------------------------------------------------------------
+SSL_DIR="$APP_DIR/.ssl"
+mkdir -p "$SSL_DIR"
+if [ ! -f "$SSL_DIR/crt.pem" ] || [ ! -f "$SSL_DIR/key.pem" ]; then
+  openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+    -keyout "$SSL_DIR/key.pem" \
+    -out    "$SSL_DIR/crt.pem" \
+    -subj   "/CN=${domain_name}"
+fi
+chown -R ubuntu:ubuntu "$SSL_DIR"
+chmod 600 "$SSL_DIR/key.pem"
+
+# ---------------------------------------------------------------------------
+# Bring up the stack
+# ---------------------------------------------------------------------------
+cd "$APP_DIR"
+sudo make start-public
+
+echo "uwflow staging bootstrap complete: $(date -u +%FT%TZ)"

--- a/staging/templates/user_data.sh.tftpl
+++ b/staging/templates/user_data.sh.tftpl
@@ -54,19 +54,29 @@ chown ubuntu:ubuntu "$ENV_FILE"
 chmod 600 "$ENV_FILE"
 
 # ---------------------------------------------------------------------------
-# Self-signed TLS cert so nginx can start.
-# TODO: replace with certbot once DNS is pointed at the EIP, e.g.
-#   docker run --rm -v "$APP_DIR/.ssl:/etc/letsencrypt" certbot/certbot \
-#     certonly --standalone -d ${domain_name} ...
+# TLS cert. If ssl_cert_path / ssl_key_path were set in tfvars, their
+# contents are inlined below and written verbatim into .ssl/. Otherwise we
+# fall back to the same self-signed recipe `make setup` uses locally
+# (script/generate-ssl-cert.sh) so dev and staging stay in sync.
+# TODO: replace with certbot once DNS is pointed at the EIP.
 # ---------------------------------------------------------------------------
 SSL_DIR="$APP_DIR/.ssl"
 mkdir -p "$SSL_DIR"
+%{ if ssl_cert != "" && ssl_key != "" ~}
+cat > "$SSL_DIR/crt.pem" <<'UWFLOW_CRT_EOF'
+${ssl_cert}
+UWFLOW_CRT_EOF
+cat > "$SSL_DIR/key.pem" <<'UWFLOW_KEY_EOF'
+${ssl_key}
+UWFLOW_KEY_EOF
+%{ else ~}
 if [ ! -f "$SSL_DIR/crt.pem" ] || [ ! -f "$SSL_DIR/key.pem" ]; then
-  openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
-    -keyout "$SSL_DIR/key.pem" \
-    -out    "$SSL_DIR/crt.pem" \
-    -subj   "/CN=${domain_name}"
+  # No cert provided — defer to `make setup`, which handles SSL cert
+  # generation (and the rest of first-boot init) as a unit.
+  cd "$APP_DIR"
+  sudo -u ubuntu make setup
 fi
+%{ endif ~}
 chown -R ubuntu:ubuntu "$SSL_DIR"
 chmod 600 "$SSL_DIR/key.pem"
 

--- a/staging/terraform.tfvars.example
+++ b/staging/terraform.tfvars.example
@@ -1,0 +1,51 @@
+key_name         = "uwflow-staging"
+domain_name      = "localhost"
+instance_type = "t3.small"
+
+# Optional: bring your own TLS cert/key. Relative paths resolve against the
+# staging/ module dir (e.g. ".ssl/crt.pem" reads staging/.ssl/crt.pem regardless
+# of where you invoke terraform from); absolute paths also work. Leave unset to
+# auto-generate a self-signed cert on the box via script/generate-ssl-cert.sh
+# (same path `make setup` takes locally).
+# ssl_cert_path = ".ssl/crt.pem"
+# ssl_key_path  = ".ssl/key.pem"
+
+app_env = {
+  # --- API ---
+  API_PORT    = "8081"
+  DOMAIN      = "localhost"
+  RUN_MODE    = "staging"
+
+  # --- Hasura ---
+  HASURA_GRAPHQL_ADMIN_SECRET      = "secretinprod"
+  HASURA_GRAPHQL_UNAUTHORIZED_ROLE = "public"
+  HASURA_GRAPHQL_JWT_KEY           = "secret"
+  HASURA_PORT                      = "8080"
+
+  # --- Sentry (leave empty to disable) ---
+  SENTRY_DSN                = ""
+  SENTRY_TRACES_SAMPLE_RATE = "0.1"
+  SENTRY_ERROR_SAMPLE_RATE  = "1.0"
+
+  # --- nginx ---
+  NGINX_HTTP_PORT  = "80"
+  NGINX_HTTPS_PORT = "443"
+
+  # --- Postgres ---
+  POSTGRES_DB       = "flow"
+  POSTGRES_HOST     = "postgres"
+  POSTGRES_PASSWORD = "secretinprod"
+  POSTGRES_PORT     = "5432"
+  POSTGRES_USER     = "postgres"
+
+  # --- UW open data API (get one from https://openapi.data.uwaterloo.ca/api-keys) ---
+  UW_API_KEY_V3 = ""
+
+  # --- Email (SMTP creds — SendGrid/Mailgun/etc.) ---
+  SMTP_SERVER   = "smtp.sendgrid.net"
+  SMTP_PORT     = "587"
+  SMTP_FROM     = "noreply@staging.uwflow.com"
+  SMTP_USERNAME = "apikey"
+  SMTP_PASSWORD = "Ignore"
+}
+

--- a/staging/variables.tf
+++ b/staging/variables.tf
@@ -20,10 +20,17 @@ variable "domain_name" {
   type        = string
 }
 
-variable "allowed_ssh_cidr" {
-  description = "CIDR allowed to SSH on port 22. WARNING: defaults to 0.0.0.0/0 for convenience. Lock this down to your IP (e.g. \"1.2.3.4/32\") for anything beyond throwaway staging."
+variable "ssl_cert_path" {
+  description = "Optional path to a PEM-encoded TLS cert. Relative paths resolve against the staging/ module dir (so \".ssl/crt.pem\" reads staging/.ssl/crt.pem); absolute paths pass through. If both this and ssl_key_path are set, the files are written to .ssl/ on the box. Otherwise a self-signed cert is generated via script/generate-ssl-cert.sh (same recipe `make setup` uses locally)."
   type        = string
-  default     = "0.0.0.0/0"
+  default     = ""
+}
+
+variable "ssl_key_path" {
+  description = "Optional path to a PEM-encoded TLS private key. Same path-resolution rules as ssl_cert_path."
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 
 variable "app_env" {

--- a/staging/variables.tf
+++ b/staging/variables.tf
@@ -1,0 +1,33 @@
+variable "aws_region" {
+  description = "AWS region to deploy into."
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type. t3.small (2 vCPU / 2 GiB) is the cheap default; bump to t3.medium (~$30/mo) if Hasura + Postgres + 3 Go services run tight on RAM."
+  type        = string
+  default     = "t3.small"
+}
+
+variable "key_name" {
+  description = "Name of an existing EC2 key pair for SSH access. SSM Session Manager works without a key, but a key pair is still handy for scp-ing pg_dump files."
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Public DNS name (e.g. staging.uwflow.com). Used as the CN of the self-signed cert and as DOMAIN inside the app. Point an A record at the output EIP."
+  type        = string
+}
+
+variable "allowed_ssh_cidr" {
+  description = "CIDR allowed to SSH on port 22. WARNING: defaults to 0.0.0.0/0 for convenience. Lock this down to your IP (e.g. \"1.2.3.4/32\") for anything beyond throwaway staging."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "app_env" {
+  description = "Key/value pairs rendered verbatim into /home/ubuntu/uwflow/.env (KEY=VALUE per line, no quoting). Holds Hasura admin secret, Postgres creds, SMTP creds, UW API key, etc. See README for the full list."
+  type        = map(string)
+  sensitive   = true
+}

--- a/staging/versions.tf
+++ b/staging/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # TODO: enable remote state for any non-throwaway environment.
+  # backend "s3" {
+  #   bucket         = "uwflow-tfstate"
+  #   key            = "staging/terraform.tfstate"
+  #   region         = "us-east-1"
+  #   dynamodb_table = "uwflow-tfstate-lock"
+  #   encrypt        = true
+  # }
+}


### PR DESCRIPTION
## Summary
- Adds the `staging/` Terraform module that stands up a single EC2 instance running the full uwflow docker-compose stack (postgres, hasura, api, uw, email, frontend/nginx).
- Supports bring-your-own TLS cert/key via `ssl_cert_path` / `ssl_key_path`; falls back to `make setup` (same recipe as local dev) when unset.
- Consolidates terraform / TLS gitignore rules at the repo root and adds `staging/terraform.tfvars.example` with placeholder `app_env` values.

## What's in here
- `main.tf` — security group (SSH/HTTP/HTTPS open for staging), IAM role + SSM, Ubuntu AMI lookup, EC2 instance, user_data templating.
- `templates/user_data.sh.tftpl` — first-boot cloud-init: installs Docker, clones the repo, writes `.env`, drops in TLS cert/key (or generates self-signed via `make setup`), brings the stack up.
- `variables.tf` / `outputs.tf` / `providers.tf` / `versions.tf` — inputs (incl. sensitive `app_env` map), public IP / DNS / SSH / SSM outputs, AWS provider pinned to `~> 5`, terraform `>= 1.6`.
- `README.md` — AWS CLI + EC2 key pair prereqs, quick start, DB seeding, TLS notes.

## Test plan
1. Follow instructions in READ.md - it should have everything necessary to deploy a staging instance
