### PR TITLE
Fix staging Hasura unauthenticated role

### DIFF
--- a/staging/terraform.tfvars.example
+++ b/staging/terraform.tfvars.example
@@ -18,7 +18,7 @@ app_env = {
 
   # --- Hasura ---
   HASURA_GRAPHQL_ADMIN_SECRET      = "secretinprod"
-  HASURA_GRAPHQL_UNAUTHORIZED_ROLE = "public"
+  HASURA_GRAPHQL_UNAUTHORIZED_ROLE = "anonymous"
   HASURA_GRAPHQL_JWT_KEY           = "secret"
   HASURA_PORT                      = "8080"
 
@@ -48,4 +48,3 @@ app_env = {
   SMTP_USERNAME = "apikey"
   SMTP_PASSWORD = "Ignore"
 }
-


### PR DESCRIPTION
TLDR: all unauthorized requests are supposed to flow through the Hasura role of `annoymous`, which is why https://ec2-3-131-38-71.us-east-2.compute.amazonaws.com/explore was not showing any data

## Summary
- set the staging Hasura unauthenticated role to `anonymous` to match existing metadata permissions
- prevents public `/graphql` requests from using the unpermitted `public` role

## Verification
- verified on the running staging EC2 instance that `HASURA_GRAPHQL_UNAUTHORIZED_ROLE=anonymous` lets `/graphql` query `course_search_index` successfully
- verified Postgres has the restored `course_search_index` data loaded (`10708` rows)

Note: I did not run `terraform apply`; this module currently replaces the instance on user-data changes, which would wipe the Docker Postgres volume.