### PR TITLE
Return 404 for missing /static/ assets instead of index.html

### DIFF
--- a/nginx/config/site.conf
+++ b/nginx/config/site.conf
@@ -45,6 +45,16 @@ server {
       stub_status;
     }
 
+    # Hashed build assets live under /static/. If a specific file is missing
+    # (e.g. a stale client requesting a chunk removed by a newer deploy),
+    # return 404 instead of falling back to index.html below. Otherwise the
+    # browser receives HTML in place of JS/CSS and fails to parse it
+    # ("SyntaxError: Unexpected token '<'").
+    location /static/ {
+      root /build;
+      try_files $uri =404;
+    }
+
     location / {
       root /build;
       try_files $uri /index.html;


### PR DESCRIPTION
## Problem

Sentry issue [7316847344](https://uwflow.com) — `SyntaxError: Unexpected token '<'` (production, `/course/:courseCode`).

The nginx catch-all serves `index.html` for **any** unresolved path:

```nginx
location / {
  try_files $uri /index.html;
}
```

When a stale browser tab requests a hashed build chunk that a newer deploy has already removed (e.g. `/static/js/8.97f247f0.chunk.js`), nginx returns `index.html` with a `200`. The browser then tries to execute `<!doctype html>…` as JavaScript and throws **`SyntaxError: Unexpected token '<'`**. The Sentry stacktrace confirms this — the chunk's "source" is literally the HTML document.

## Fix

Add a dedicated `location /static/` block that returns `404` for missing assets instead of falling back to `index.html`:

```nginx
location /static/ {
  root /build;
  try_files $uri =404;
}
```

- All hashed webpack output lives under `/static/` (`static/js/[name].[contenthash].chunk.js`, `static/css/`, `static/media/`), per `config/webpack.config.js`.
- `/static/` is a longer prefix than `/`, so nginx routes asset requests here automatically; real SPA routes (e.g. `/course/stat337`) still fall through to `index.html`.
- Uses the nginx runtime variable `$uri`. `run.sh` runs `envsubst` with an explicit allowlist, so `$uri` is preserved.

A missing chunk now returns a clean `404` instead of mis-typed HTML, so the browser surfaces a normal chunk-load failure rather than a confusing `SyntaxError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)