### PR TITLE
Fix duplicate section import for cross-listed courses

### DIFF
--- a/flow/importer/uw/parts/course/convert.go
+++ b/flow/importer/uw/parts/course/convert.go
@@ -190,6 +190,14 @@ func convertAll(
 		convertCourse(dst, &apiCourse)
 	}
 
+	// The DB enforces (class_number, term_id) uniqueness; a duplicate in the
+	// batch would abort the entire section import, so drop it here instead.
+	type sectionKey struct {
+		classNumber int
+		termId      int
+	}
+	seenSections := make(map[sectionKey]bool)
+
 	for _, apiClass := range apiClasses {
 		if apiClass.TermId == nil {
 			continue
@@ -199,6 +207,16 @@ func convertAll(
 		if err != nil {
 			continue
 		}
+
+		key := sectionKey{apiClass.ClassNumber, termId}
+		if seenSections[key] {
+			log.Warnf(
+				"skipping duplicate section: class %d in term %d (course %s)",
+				apiClass.ClassNumber, termId, apiClass.CourseCode,
+			)
+			continue
+		}
+		seenSections[key] = true
 
 		term := idToTerm[termId]
 		err = convertSection(dst, &apiClass, term)

--- a/flow/importer/uw/parts/course/convert_test.go
+++ b/flow/importer/uw/parts/course/convert_test.go
@@ -463,6 +463,62 @@ func TestConvertSection(t *testing.T) {
 	}
 }
 
+func TestConvertAllDedupesSections(t *testing.T) {
+	termCode := "1265"
+	component := "LEC"
+	idToTerm := map[int]*term.Term{
+		1265: {
+			Id:        1265,
+			StartDate: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:   time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	// The same class appearing twice in a batch, as happens when a
+	// cross-listed course is fetched under more than one course code.
+	classes := []apiClass{
+		{
+			CourseCode:      "soc327",
+			ClassNumber:     2383,
+			CourseComponent: &component,
+			SectionNumber:   81,
+			TermId:          &termCode,
+		},
+		{
+			CourseCode:      "ls327",
+			ClassNumber:     2383,
+			CourseComponent: &component,
+			SectionNumber:   81,
+			TermId:          &termCode,
+		},
+		{
+			CourseCode:      "ls327",
+			ClassNumber:     2387,
+			CourseComponent: &component,
+			SectionNumber:   81,
+			TermId:          &termCode,
+		},
+	}
+
+	var got convertResult
+	err := convertAll(&got, nil, classes, idToTerm)
+	if err != nil {
+		t.Errorf("error: %v", err)
+	}
+
+	if len(got.Sections) != 2 {
+		t.Fatalf("expected 2 sections after dedup, got %d", len(got.Sections))
+	}
+	if got.Sections[0].CourseCode != "soc327" || got.Sections[0].ClassNumber != 2383 {
+		t.Errorf("expected first section soc327/2383, got %s/%d",
+			got.Sections[0].CourseCode, got.Sections[0].ClassNumber)
+	}
+	if got.Sections[1].CourseCode != "ls327" || got.Sections[1].ClassNumber != 2387 {
+		t.Errorf("expected second section ls327/2387, got %s/%d",
+			got.Sections[1].CourseCode, got.Sections[1].ClassNumber)
+	}
+}
+
 func TestParsePrereqs(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/flow/importer/uw/parts/course/fetch.go
+++ b/flow/importer/uw/parts/course/fetch.go
@@ -15,6 +15,13 @@ import (
 // count against the same quota.
 const classRequestDelay = 550 * time.Millisecond
 
+// courseOffer identifies one cross-listed code of a course: codes sharing a
+// courseId are distinguished by courseOfferNumber.
+type courseOffer struct {
+	courseId    string
+	offerNumber int
+}
+
 func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error) {
 	// Fetch course data
 	courses, err := fetchCourses(client, termIds)
@@ -22,14 +29,31 @@ func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error
 		return nil, nil, fmt.Errorf("failed to fetch courses: %w", err)
 	}
 
+	// Cross-listed codes (e.g. SOC 327 and LS 327) share a courseId, and
+	// ClassSchedules/{term}/{courseId} returns the sections of all of them.
+	// Fetch each courseId only once per term so the same section is never
+	// imported twice, and map each returned class back to its course code
+	// via its courseOfferNumber.
+	offerToCode := make(map[courseOffer]string)
+	seenCourseId := make(map[string]bool)
+	var uniqueCourses []apiCourse
+	for _, course := range courses {
+		offer := courseOffer{course.CourseId, course.CourseOfferNumber}
+		offerToCode[offer] = strings.ToLower(course.Subject + course.Number)
+		if !seenCourseId[course.CourseId] {
+			seenCourseId[course.CourseId] = true
+			uniqueCourses = append(uniqueCourses, course)
+		}
+	}
+
 	// Fetch class schedules for all returned courses, for upcoming terms.
 	// Requests are kept sequential (one at a time) with a small inter-request
 	// delay to avoid triggering API rate limits.
 	var classes []apiClass
-	numClasses := len(courses) * len(termIds)
+	numClasses := len(uniqueCourses) * len(termIds)
 	numFetched := 0
 
-	for _, course := range courses {
+	for _, course := range uniqueCourses {
 		for _, termId := range termIds {
 			fetched, err := fetchClass(client, &course, termId)
 			numFetched++
@@ -41,7 +65,12 @@ func fetchAll(client *api.Client, termIds []int) ([]apiCourse, []apiClass, error
 				log.Warnf("failed to fetch section with error %s, proceeding anyway", err)
 			} else {
 				for _, class := range fetched {
-					class.CourseCode = strings.ToLower(course.Subject + course.Number)
+					offer := courseOffer{class.CourseId, class.CourseOfferNumber}
+					if code, ok := offerToCode[offer]; ok {
+						class.CourseCode = code
+					} else {
+						class.CourseCode = strings.ToLower(course.Subject + course.Number)
+					}
 					classes = append(classes, class)
 				}
 			}

--- a/flow/importer/uw/parts/course/struct.go
+++ b/flow/importer/uw/parts/course/struct.go
@@ -64,16 +64,19 @@ type antireq struct {
 }
 
 type apiCourse struct {
-	CourseId     string  `json:"courseId"`
-	Subject      string  `json:"subjectCode"`
-	Number       string  `json:"catalogNumber"`
-	Name         string  `json:"title"`
-	Description  *string `json:"description"`
-	Requirements *string `json:"requirementsDescription"`
+	CourseId          string  `json:"courseId"`
+	CourseOfferNumber int     `json:"courseOfferNumber"`
+	Subject           string  `json:"subjectCode"`
+	Number            string  `json:"catalogNumber"`
+	Name              string  `json:"title"`
+	Description       *string `json:"description"`
+	Requirements      *string `json:"requirementsDescription"`
 }
 
 type apiClass struct {
 	CourseCode         string               // Must be populated manually
+	CourseId           string               `json:"courseId"`
+	CourseOfferNumber  int                  `json:"courseOfferNumber"`
 	ClassNumber        int                  `json:"classNumber"`
 	CourseComponent    *string              `json:"courseComponent"`
 	SectionNumber      int                  `json:"classSection"`


### PR DESCRIPTION
non-ai slop description:

basically, the API introduced a new property called `courseOffering` and the importer assumed course_id was a unique identifying key for importing the classes

```go
  // TEMP: test only the SOC 327 / LS 327 cross-listed pair (courseId 009873)
  var testCourses []apiCourse
  for _, course := range uniqueCourses {
        if course.CourseId == "009873" {
                testCourses = append(testCourses, course)
        }
  }
```

testing evidence:
<img width="2549" height="796" alt="image" src="https://github.com/user-attachments/assets/25df402d-3542-47a5-9cfb-20cf833c5f5c" />


## Description

The prod importer has been failing on every run with:

```
API import failed: failed to insert sections: failed to insert: ERROR: duplicate key value violates unique constraint "class_number_unique_to_term" (SQLSTATE 23505)
```

This rolls back the entire section + meeting import, so no section/meeting data has been refreshed since it started (and Fall 2026 sections are missing entirely).

## Root cause

#181 switched section fetching to `ClassSchedules/{term}/{courseId}` (required by the UW API change), but **cross-listed courses share a single `courseId`** while the course list is deduped by course *code*. Spring 2026 has 537 courseIds shared by 2+ codes; Fall 2026 has 529.

Verified against the live API with SOC 327 / LS 327 (both `courseId` 009873):

- `ClassSchedules/1265/009873` returns class numbers **2383 and 2387** (the sections of *all* cross-listed codes, merged)
- the old by-code endpoint returned only 2383 for `SOC/327` and only 2387 for `LS/327`

So every cross-listed course was fetched once per code, and identical `(classNumber, termCode)` rows entered the batch multiple times. The insert query only excludes rows already present in `course_section`, so duplicates *within the batch* both pass the `WHERE cs.id IS NULL` filter. While all cross-listed sections already existed in the DB the UPDATE path absorbed them, but as soon as a *new* cross-listed section appeared (Fall 2026 schedules being published), the INSERT hit the unique constraint and the transaction rolled back — permanently, on every subsequent run.

## What this PR does

1. **Fetch each distinct `courseId` once per term** instead of once per course code. Side benefit: ~2,100 fewer requests per run against the 120 req/min quota.
2. **Attribute each returned class to its correct course code via `(courseId, courseOfferNumber)`** — the API exposes `courseOfferNumber` in both the Courses and ClassSchedules responses to distinguish cross-listed codes (SOC 327 = offer 1, LS 327 = offer 2). This restores the pre-#181 attribution where each cross-listed code keeps its own sections.
3. **Safety net in `convertAll`:** skip any duplicate `(classNumber, termId)` in a batch with a warning, so an API quirk can never abort the whole import again.
4. Adds a unit test for the dedup behavior.

## Expected prod side effects (self-healing)

Since #181 deployed, cross-listed courses have had duplicated meetings and possibly wrong `course_id` attribution in prod. Both heal on the first successful run of this fix: meetings are delete-and-reinserted per import, and the section UPDATE rewrites `course_id`.

## How to test

1. Start services locally
2. In `flow/importer/uw/parts/course/fetch.go`, temporarily filter the fetch loop to a cross-listed pair, e.g. SOC 327 / LS 327
3. Run `make import-course`
4. Expect: import completes without the 23505 error, SOC 327 has class 2383, LS 327 has class 2387 (matching [the official schedule](https://classes.uwaterloo.ca/cgi-bin/cgiwrap/infocour/salook.pl?level=under&sess=1265&subject=SOC&cournum=327)), and neither course has duplicated meetings
5. `cd flow && go test ./importer/uw/parts/course/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)