### PR TITLE
Ingest Quest professor teaching data

### DIFF
--- a/flow/api/admin/README.md
+++ b/flow/api/admin/README.md
@@ -1,0 +1,38 @@
+# Professor teaching ingestion
+
+`POST /admin/prof-teaches/ingest` ingests one or more term buckets from
+`prof_teaches.json`. The public Nginx proxy intentionally returns 404 for all
+`/api/admin/` routes. Run the request on the backend host, through an SSH
+tunnel, or from another container on the private network.
+
+Send the existing Hasura admin secret in `X-Hasura-Admin-Secret`:
+
+```sh
+curl --fail-with-body \
+  -H "Content-Type: application/json" \
+  -H "X-Hasura-Admin-Secret: $HASURA_GRAPHQL_ADMIN_SECRET" \
+  --data-binary @prof_teaches.json \
+  http://localhost:8081/admin/prof-teaches/ingest
+```
+
+The endpoint validates the complete request and all referenced term/course IDs
+before writing. `course_id` must identify the supplied `course_code`. Duplicate
+rows in one file are collapsed by `(term_code, course_id, instructor)`, keeping
+the latest `scraped_at` value. Successful writes refresh the professor/course
+search materializations before the response returns.
+
+A successful response reports both source and write counts:
+
+```json
+{
+  "terms_processed": 3,
+  "records_received": 6172,
+  "unique_records": 6172,
+  "professors_created": 0,
+  "records_written": 6172
+}
+```
+
+Re-sending unchanged data returns `records_written: 0`. Validation failures use
+HTTP 400 and include each invalid JSON path. Missing or incorrect credentials
+return HTTP 401.

--- a/flow/api/admin/ingest.go
+++ b/flow/api/admin/ingest.go
@@ -1,0 +1,553 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"flow/api/serde"
+	"flow/common/db"
+	"flow/common/util"
+)
+
+const scrapedAtLayout = "2006-01-02 03:04 PM"
+
+var (
+	courseCodePattern = regexp.MustCompile(`^[a-z0-9]+$`)
+	scrapedAtPattern  = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2} (AM|PM)$`)
+)
+
+type rawTerm struct {
+	TermCode *int         `json:"term_code"`
+	TermName *string      `json:"term_name"`
+	Data     *[]rawRecord `json:"data"`
+}
+
+type rawRecord struct {
+	CourseCode *string `json:"course_code"`
+	CourseID   *int    `json:"course_id"`
+	Instructor *string `json:"instructor"`
+	ScrapedAt  *string `json:"scraped_at"`
+}
+
+type teachingRecord struct {
+	termCode   int
+	termName   string
+	courseCode string
+	courseID   int
+	instructor string
+	profCode   string
+	scrapedAt  time.Time
+	path       string
+}
+
+type termReference struct {
+	path string
+}
+
+type courseReference struct {
+	code string
+	path string
+}
+
+type validatedPayload struct {
+	records         []teachingRecord
+	terms           map[int]termReference
+	courses         map[int]courseReference
+	recordsReceived int
+}
+
+type validationDetail struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+type teachingKey struct {
+	termCode   int
+	courseID   int
+	instructor string
+}
+
+type ingestResponse struct {
+	TermsProcessed    int `json:"terms_processed"`
+	RecordsReceived   int `json:"records_received"`
+	UniqueRecords     int `json:"unique_records"`
+	ProfessorsCreated int `json:"professors_created"`
+	RecordsWritten    int `json:"records_written"`
+}
+
+const insertProfessorsQuery = `
+WITH input(name, code) AS (
+  SELECT * FROM UNNEST($1::text[], $2::text[])
+)
+INSERT INTO public.prof(name, code)
+SELECT input.name, input.code
+FROM input
+LEFT JOIN public.prof_remap remap ON remap.code = input.code
+LEFT JOIN public.prof ON prof.code = input.code
+WHERE remap.prof_id IS NULL AND prof.id IS NULL
+ON CONFLICT (code) DO NOTHING
+`
+
+const upsertTeachingRecordsQuery = `
+WITH input(
+  term_code, term_name, course_id, course_code,
+  instructor, prof_code, scraped_at
+) AS (
+  SELECT * FROM UNNEST(
+    $1::int[], $2::text[], $3::int[], $4::text[],
+    $5::text[], $6::text[], $7::timestamp[]
+  )
+), resolved AS (
+  SELECT
+    input.term_code,
+    input.term_name,
+    input.course_id,
+    input.course_code,
+    input.instructor,
+    COALESCE(remap.prof_id, prof.id) AS prof_id,
+    input.scraped_at
+  FROM input
+  LEFT JOIN public.prof_remap remap ON remap.code = input.prof_code
+  LEFT JOIN public.prof prof ON prof.code = input.prof_code
+)
+INSERT INTO public.prof_teaches_course_ingestion(
+  term_code, term_name, course_id, course_code,
+  instructor, prof_id, scraped_at
+)
+SELECT
+  term_code, term_name, course_id, course_code,
+  instructor, prof_id, scraped_at
+FROM resolved
+ON CONFLICT (term_code, course_id, instructor) DO UPDATE SET
+  term_name = EXCLUDED.term_name,
+  course_code = EXCLUDED.course_code,
+  prof_id = EXCLUDED.prof_id,
+  scraped_at = EXCLUDED.scraped_at,
+  ingested_at = NOW()
+WHERE (
+  prof_teaches_course_ingestion.term_name,
+  prof_teaches_course_ingestion.course_code,
+  prof_teaches_course_ingestion.prof_id,
+  prof_teaches_course_ingestion.scraped_at
+) IS DISTINCT FROM (
+  EXCLUDED.term_name,
+  EXCLUDED.course_code,
+  EXCLUDED.prof_id,
+  EXCLUDED.scraped_at
+)
+`
+
+func IngestProfTeaches(tx *db.Tx, r *http.Request) (interface{}, error) {
+	payload, details, err := decodeAndValidate(r.Body)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return nil, validationError(
+				http.StatusRequestEntityTooLarge,
+				[]validationDetail{{Path: "$", Message: "request body exceeds 10 MiB"}},
+			)
+		}
+		return nil, validationError(
+			http.StatusBadRequest,
+			[]validationDetail{{Path: "$", Message: err.Error()}},
+		)
+	}
+	if len(details) > 0 {
+		return nil, validationError(http.StatusBadRequest, details)
+	}
+
+	details, err = validateReferences(tx, payload)
+	if err != nil {
+		return nil, fmt.Errorf("validating database references: %w", err)
+	}
+	if len(details) > 0 {
+		return nil, validationError(http.StatusBadRequest, details)
+	}
+
+	response := ingestResponse{
+		TermsProcessed:  len(payload.terms),
+		RecordsReceived: payload.recordsReceived,
+		UniqueRecords:   len(payload.records),
+	}
+	if len(payload.records) == 0 {
+		return response, nil
+	}
+
+	profNames, profCodes := uniqueProfessors(payload.records)
+	inserted, err := tx.Exec(insertProfessorsQuery, profNames, profCodes)
+	if err != nil {
+		return nil, fmt.Errorf("inserting professors: %w", err)
+	}
+	response.ProfessorsCreated = int(inserted.RowsAffected())
+
+	termCodes := make([]int, len(payload.records))
+	termNames := make([]string, len(payload.records))
+	courseIDs := make([]int, len(payload.records))
+	courseCodes := make([]string, len(payload.records))
+	instructors := make([]string, len(payload.records))
+	recordProfCodes := make([]string, len(payload.records))
+	scrapedAt := make([]time.Time, len(payload.records))
+	for i, record := range payload.records {
+		termCodes[i] = record.termCode
+		termNames[i] = record.termName
+		courseIDs[i] = record.courseID
+		courseCodes[i] = record.courseCode
+		instructors[i] = record.instructor
+		recordProfCodes[i] = record.profCode
+		scrapedAt[i] = record.scrapedAt
+	}
+
+	written, err := tx.Exec(
+		upsertTeachingRecordsQuery,
+		termCodes,
+		termNames,
+		courseIDs,
+		courseCodes,
+		instructors,
+		recordProfCodes,
+		scrapedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("upserting teaching records: %w", err)
+	}
+	response.RecordsWritten = int(written.RowsAffected())
+
+	return response, nil
+}
+
+func decodeAndValidate(body io.Reader) (validatedPayload, []validationDetail, error) {
+	var payload validatedPayload
+	var rawTerms *[]rawTerm
+
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&rawTerms); err != nil {
+		return payload, nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if rawTerms == nil {
+		return payload, nil, fmt.Errorf("top-level value must be an array")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return payload, nil, fmt.Errorf("request body must contain exactly one JSON value")
+	}
+
+	payload.terms = make(map[int]termReference)
+	payload.courses = make(map[int]courseReference)
+	seenRecords := make(map[teachingKey]int)
+	termNames := make(map[int]string)
+	var details []validationDetail
+
+	for termIndex, rawTerm := range *rawTerms {
+		termPath := fmt.Sprintf("$[%d]", termIndex)
+		termValid := true
+
+		if rawTerm.TermCode == nil {
+			details = append(details, required(termPath+".term_code", "integer"))
+			termValid = false
+		} else if *rawTerm.TermCode <= 0 {
+			details = append(details, validationDetail{
+				Path: termPath + ".term_code", Message: "must be greater than zero",
+			})
+			termValid = false
+		}
+
+		termName := ""
+		if rawTerm.TermName == nil {
+			details = append(details, required(termPath+".term_name", "string"))
+			termValid = false
+		} else {
+			termName = strings.TrimSpace(*rawTerm.TermName)
+			if termName == "" {
+				details = append(details, validationDetail{
+					Path: termPath + ".term_name", Message: "must not be empty",
+				})
+				termValid = false
+			} else if len(termName) > 256 {
+				details = append(details, validationDetail{
+					Path: termPath + ".term_name", Message: "must be at most 256 bytes",
+				})
+				termValid = false
+			}
+		}
+
+		if rawTerm.Data == nil {
+			details = append(details, required(termPath+".data", "array"))
+			continue
+		}
+
+		if termValid {
+			termCode := *rawTerm.TermCode
+			if existingName, ok := termNames[termCode]; ok && existingName != termName {
+				details = append(details, validationDetail{
+					Path: termPath + ".term_name",
+					Message: fmt.Sprintf(
+						"conflicts with another name for term_code %d", termCode,
+					),
+				})
+				termValid = false
+			} else {
+				termNames[termCode] = termName
+				payload.terms[termCode] = termReference{
+					path: termPath + ".term_code",
+				}
+			}
+		}
+
+		for recordIndex, rawRecord := range *rawTerm.Data {
+			payload.recordsReceived++
+			recordPath := fmt.Sprintf("%s.data[%d]", termPath, recordIndex)
+			record, recordDetails := validateRecord(rawRecord, recordPath)
+			details = append(details, recordDetails...)
+			if !termValid || len(recordDetails) > 0 {
+				continue
+			}
+
+			record.termCode = *rawTerm.TermCode
+			record.termName = termName
+			record.path = recordPath
+
+			if existing, ok := payload.courses[record.courseID]; ok {
+				if existing.code != record.courseCode {
+					details = append(details, validationDetail{
+						Path: recordPath + ".course_code",
+						Message: fmt.Sprintf(
+							"conflicts with %s for course_id %d",
+							existing.path+".course_code", record.courseID,
+						),
+					})
+					continue
+				}
+			} else {
+				payload.courses[record.courseID] = courseReference{
+					code: record.courseCode, path: recordPath,
+				}
+			}
+
+			key := teachingKey{
+				termCode: record.termCode, courseID: record.courseID,
+				instructor: record.instructor,
+			}
+			if existingIndex, ok := seenRecords[key]; ok {
+				if record.scrapedAt.After(payload.records[existingIndex].scrapedAt) {
+					payload.records[existingIndex].scrapedAt = record.scrapedAt
+				}
+				continue
+			}
+			seenRecords[key] = len(payload.records)
+			payload.records = append(payload.records, record)
+		}
+	}
+
+	return payload, details, nil
+}
+
+func validateRecord(raw rawRecord, path string) (teachingRecord, []validationDetail) {
+	var record teachingRecord
+	var details []validationDetail
+
+	if raw.CourseCode == nil {
+		details = append(details, required(path+".course_code", "string"))
+	} else {
+		record.courseCode = *raw.CourseCode
+		if len(record.courseCode) == 0 {
+			details = append(details, validationDetail{
+				Path: path + ".course_code", Message: "must not be empty",
+			})
+		} else if len(record.courseCode) > 16 {
+			details = append(details, validationDetail{
+				Path: path + ".course_code", Message: "must be at most 16 bytes",
+			})
+		} else if !courseCodePattern.MatchString(record.courseCode) {
+			details = append(details, validationDetail{
+				Path:    path + ".course_code",
+				Message: "must be a lowercase compact course code",
+			})
+		}
+	}
+
+	if raw.CourseID == nil {
+		details = append(details, required(path+".course_id", "integer"))
+	} else if *raw.CourseID <= 0 {
+		details = append(details, validationDetail{
+			Path: path + ".course_id", Message: "must be greater than zero",
+		})
+	} else {
+		record.courseID = *raw.CourseID
+	}
+
+	if raw.Instructor == nil {
+		details = append(details, required(path+".instructor", "string"))
+	} else {
+		record.instructor = strings.TrimSpace(*raw.Instructor)
+		if record.instructor == "" {
+			details = append(details, validationDetail{
+				Path: path + ".instructor", Message: "must not be empty",
+			})
+		} else if len(record.instructor) > 256 {
+			details = append(details, validationDetail{
+				Path: path + ".instructor", Message: "must be at most 256 bytes",
+			})
+		} else {
+			record.profCode = util.ProfNameToCode(record.instructor)
+			if record.profCode == "" {
+				details = append(details, validationDetail{
+					Path:    path + ".instructor",
+					Message: "must contain at least one Latin letter",
+				})
+			}
+		}
+	}
+
+	if raw.ScrapedAt == nil {
+		details = append(details, required(path+".scraped_at", "string"))
+	} else if !scrapedAtPattern.MatchString(*raw.ScrapedAt) {
+		details = append(details, validationDetail{
+			Path:    path + ".scraped_at",
+			Message: "must match YYYY-MM-DD HH:MM AM/PM",
+		})
+	} else {
+		parsed, err := time.Parse(scrapedAtLayout, *raw.ScrapedAt)
+		if err != nil {
+			details = append(details, validationDetail{
+				Path: path + ".scraped_at", Message: "must be a valid date and time",
+			})
+		} else {
+			record.scrapedAt = parsed
+		}
+	}
+
+	return record, details
+}
+
+func validateReferences(
+	tx *db.Tx, payload validatedPayload,
+) ([]validationDetail, error) {
+	var details []validationDetail
+
+	termIDs := make([]int, 0, len(payload.terms))
+	for termID := range payload.terms {
+		termIDs = append(termIDs, termID)
+	}
+	sort.Ints(termIDs)
+	if len(termIDs) > 0 {
+		rows, err := tx.Query(`SELECT id FROM public.term WHERE id = ANY($1::int[])`, termIDs)
+		if err != nil {
+			return nil, err
+		}
+		found := make(map[int]bool, len(termIDs))
+		for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			found[id] = true
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		rows.Close()
+		for _, id := range termIDs {
+			if !found[id] {
+				details = append(details, validationDetail{
+					Path:    payload.terms[id].path,
+					Message: fmt.Sprintf("term_code %d does not exist", id),
+				})
+			}
+		}
+	}
+
+	courseIDs := make([]int, 0, len(payload.courses))
+	for courseID := range payload.courses {
+		courseIDs = append(courseIDs, courseID)
+	}
+	sort.Ints(courseIDs)
+	if len(courseIDs) > 0 {
+		rows, err := tx.Query(
+			`SELECT id, code FROM public.course WHERE id = ANY($1::int[])`,
+			courseIDs,
+		)
+		if err != nil {
+			return nil, err
+		}
+		found := make(map[int]string, len(courseIDs))
+		for rows.Next() {
+			var id int
+			var code string
+			if err := rows.Scan(&id, &code); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			found[id] = code
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		rows.Close()
+		for _, id := range courseIDs {
+			reference := payload.courses[id]
+			code, ok := found[id]
+			if !ok {
+				details = append(details, validationDetail{
+					Path:    reference.path + ".course_id",
+					Message: fmt.Sprintf("course_id %d does not exist", id),
+				})
+			} else if code != reference.code {
+				details = append(details, validationDetail{
+					Path: reference.path + ".course_code",
+					Message: fmt.Sprintf(
+						"course_id %d belongs to %q, not %q", id, code, reference.code,
+					),
+				})
+			}
+		}
+	}
+
+	return details, nil
+}
+
+func uniqueProfessors(records []teachingRecord) ([]string, []string) {
+	byCode := make(map[string]string)
+	for _, record := range records {
+		if _, exists := byCode[record.profCode]; !exists {
+			byCode[record.profCode] = record.instructor
+		}
+	}
+
+	codes := make([]string, 0, len(byCode))
+	for code := range byCode {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+
+	names := make([]string, len(codes))
+	for i, code := range codes {
+		names[i] = byCode[code]
+	}
+	return names, codes
+}
+
+func required(path, expectedType string) validationDetail {
+	return validationDetail{
+		Path: path, Message: fmt.Sprintf("is required and must be a %s", expectedType),
+	}
+}
+
+func validationError(status int, details []validationDetail) error {
+	return serde.WithDetails(
+		details,
+		serde.WithEnum(
+			serde.ValidationFailed,
+			serde.WithStatus(status, fmt.Errorf("ingestion payload failed validation")),
+		),
+	)
+}

--- a/flow/api/admin/ingest_test.go
+++ b/flow/api/admin/ingest_test.go
@@ -1,0 +1,154 @@
+package admin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeAndValidateMultiTermPayload(t *testing.T) {
+	body := `[
+  {
+    "term_code": 1265,
+    "term_name": "Spring 2026",
+    "data": [
+      {
+        "course_code": "acc610",
+        "course_id": 7,
+        "instructor": "Lisa Pynenburg",
+        "scraped_at": "2026-06-16 08:47 PM"
+      },
+      {
+        "course_code": "acc610",
+        "course_id": 7,
+        "instructor": "Lisa Pynenburg",
+        "scraped_at": "2026-06-17 08:47 PM"
+      }
+    ]
+  },
+  {
+    "term_code": 1261,
+    "term_name": "Winter 2026",
+    "data": [
+      {
+        "course_code": "acc606",
+        "course_id": 3,
+        "instructor": "Wayne Chang",
+        "scraped_at": "2026-06-16 08:47 PM"
+      }
+    ]
+  }
+]`
+
+	payload, details, err := decodeAndValidate(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("decodeAndValidate returned error: %v", err)
+	}
+	if len(details) != 0 {
+		t.Fatalf("validation details = %#v, want none", details)
+	}
+	if payload.recordsReceived != 3 {
+		t.Fatalf("records received = %d, want 3", payload.recordsReceived)
+	}
+	if len(payload.records) != 2 {
+		t.Fatalf("unique records = %d, want 2", len(payload.records))
+	}
+	if len(payload.terms) != 2 {
+		t.Fatalf("terms = %d, want 2", len(payload.terms))
+	}
+	if got := payload.records[0].scrapedAt.Format(scrapedAtLayout); got != "2026-06-17 08:47 PM" {
+		t.Fatalf("duplicate retained scraped_at %q, want latest value", got)
+	}
+}
+
+func TestDecodeAndValidateCollectsFieldErrors(t *testing.T) {
+	body := `[
+  {
+    "term_name": " ",
+    "data": [
+      {
+        "course_code": "ACC 610",
+        "instructor": " ",
+        "scraped_at": "2026-13-16 08:47 PM"
+      }
+    ]
+  }
+]`
+
+	_, details, err := decodeAndValidate(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("decodeAndValidate returned error: %v", err)
+	}
+
+	wantPaths := map[string]bool{
+		"$[0].term_code":           false,
+		"$[0].term_name":           false,
+		"$[0].data[0].course_code": false,
+		"$[0].data[0].course_id":   false,
+		"$[0].data[0].instructor":  false,
+		"$[0].data[0].scraped_at":  false,
+	}
+	for _, detail := range details {
+		if _, ok := wantPaths[detail.Path]; ok {
+			wantPaths[detail.Path] = true
+		}
+	}
+	for path, found := range wantPaths {
+		if !found {
+			t.Errorf("missing validation error for %s; got %#v", path, details)
+		}
+	}
+}
+
+func TestDecodeAndValidateRejectsInvalidJSONShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "top-level object", body: `{}`, want: "cannot unmarshal object"},
+		{name: "top-level null", body: `null`, want: "top-level value must be an array"},
+		{
+			name: "unknown field",
+			body: `[{"term_code":1265,"term_name":"Spring 2026","data":[],"extra":true}]`,
+			want: "unknown field",
+		},
+		{name: "multiple values", body: `[] []`, want: "exactly one JSON value"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := decodeAndValidate(strings.NewReader(test.body))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeAndValidateRejectsConflictingCourseCodes(t *testing.T) {
+	body := `[
+  {
+    "term_code": 1265,
+    "term_name": "Spring 2026",
+    "data": [
+      {"course_code":"acc610","course_id":7,"instructor":"One Prof","scraped_at":"2026-06-16 08:47 PM"},
+      {"course_code":"cs135","course_id":7,"instructor":"Other Prof","scraped_at":"2026-06-16 08:47 PM"}
+    ]
+  }
+]`
+
+	_, details, err := decodeAndValidate(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("decodeAndValidate returned error: %v", err)
+	}
+	if len(details) != 1 || details[0].Path != "$[0].data[1].course_code" {
+		t.Fatalf("validation details = %#v, want conflicting course code", details)
+	}
+}
+
+func TestDecodeAndValidateAcceptsEmptyArray(t *testing.T) {
+	payload, details, err := decodeAndValidate(strings.NewReader(`[]`))
+	if err != nil || len(details) != 0 || len(payload.records) != 0 {
+		t.Fatalf("empty array result = (%#v, %#v, %v), want valid no-op", payload, details, err)
+	}
+}

--- a/flow/api/main.go
+++ b/flow/api/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	_ "time/tzdata"
 
+	"flow/api/admin"
 	"flow/api/auth"
 	"flow/api/calendar"
 	"flow/api/data"
@@ -97,6 +98,18 @@ func setupRouter(conn *db.Conn) *chi.Mux {
 	router.Delete(
 		"/user",
 		serde.WithDbDirect(conn, auth.DeleteAccount, "account deletion"),
+	)
+
+	profTeachesIngest := http.MaxBytesHandler(
+		serde.WithDbResponse(conn, admin.IngestProfTeaches, "professor teaching ingestion"),
+		10<<20,
+	)
+	router.With(
+		middleware.RequireAdminSecret(env.Global.HasuraAdminSecret),
+	).Method(
+		http.MethodPost,
+		"/admin/prof-teaches/ingest",
+		profTeachesIngest,
 	)
 
 	return router

--- a/flow/api/middleware/middleware.go
+++ b/flow/api/middleware/middleware.go
@@ -1,10 +1,37 @@
 package middleware
 
 import (
+	"crypto/subtle"
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/url"
 )
+
+type authError struct {
+	Error string `json:"error"`
+}
+
+// RequireAdminSecret protects server-to-server endpoints with the same secret
+// used for Hasura administrative requests.
+func RequireAdminSecret(secret string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			provided := r.Header.Get("X-Hasura-Admin-Secret")
+			valid := secret != "" && provided != "" &&
+				subtle.ConstantTimeCompare([]byte(provided), []byte(secret)) == 1
+			if !valid {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Cache-Control", "no-store")
+				w.WriteHeader(http.StatusUnauthorized)
+				_ = json.NewEncoder(w).Encode(authError{Error: "unauthorized"})
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
 
 // CORS middleware for localhost environments
 func CorsLocalhostMiddleware() func(http.Handler) http.Handler {

--- a/flow/api/middleware/middleware_test.go
+++ b/flow/api/middleware/middleware_test.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequireAdminSecret(t *testing.T) {
+	const secret = "test-secret"
+
+	tests := []struct {
+		name           string
+		configured     string
+		provided       string
+		wantStatusCode int
+		wantCalled     bool
+	}{
+		{
+			name: "valid secret", configured: secret, provided: secret,
+			wantStatusCode: http.StatusNoContent, wantCalled: true,
+		},
+		{
+			name: "missing secret", configured: secret,
+			wantStatusCode: http.StatusUnauthorized,
+		},
+		{
+			name: "incorrect secret", configured: secret, provided: "wrong",
+			wantStatusCode: http.StatusUnauthorized,
+		},
+		{
+			name:           "empty server configuration",
+			wantStatusCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			handler := RequireAdminSecret(test.configured)(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					called = true
+					w.WriteHeader(http.StatusNoContent)
+				},
+			))
+
+			request := httptest.NewRequest(http.MethodPost, "/admin", nil)
+			if test.provided != "" {
+				request.Header.Set("X-Hasura-Admin-Secret", test.provided)
+			}
+			response := httptest.NewRecorder()
+
+			handler.ServeHTTP(response, request)
+
+			if response.Code != test.wantStatusCode {
+				t.Fatalf("status = %d, want %d", response.Code, test.wantStatusCode)
+			}
+			if called != test.wantCalled {
+				t.Fatalf("downstream called = %t, want %t", called, test.wantCalled)
+			}
+			if !test.wantCalled && response.Body.String() != "{\"error\":\"unauthorized\"}\n" {
+				t.Fatalf("unexpected unauthorized response: %s", response.Body.String())
+			}
+		})
+	}
+}

--- a/flow/api/serde/error.go
+++ b/flow/api/serde/error.go
@@ -43,6 +43,10 @@ const (
 	// Transcript contains no terms
 	EmptyTranscript = "empty_transcript"
 
+	//// Administrative ingestion
+	// Administrative ingestion payload failed validation
+	ValidationFailed = "validation_failed"
+
 	//// Fallbacks
 	// These do not map exactly to 400 and 500 status codes respectively:
 	// - BadRequest represents all otherwise unidentified client errors
@@ -93,9 +97,31 @@ func WithStatus(status int, err error) error {
 	return statusErr{err: err, status: status}
 }
 
+type detailsErr struct {
+	details interface{}
+	err     error
+}
+
+func (e detailsErr) Details() interface{} {
+	return e.details
+}
+
+func (e detailsErr) Error() string {
+	return e.err.Error()
+}
+
+func (e detailsErr) Unwrap() error {
+	return e.err
+}
+
+func WithDetails(details interface{}, err error) error {
+	return detailsErr{details: details, err: err}
+}
+
 type errorPayload struct {
-	Enum      string `json:"error"`
-	RequestId string `json:"request_id"`
+	Enum      string      `json:"error"`
+	RequestId string      `json:"request_id"`
+	Details   interface{} `json:"details,omitempty"`
 }
 
 func Error(w http.ResponseWriter, r *http.Request, err error) {
@@ -130,6 +156,11 @@ func Error(w http.ResponseWriter, r *http.Request, err error) {
 		} else {
 			payload.Enum = BadRequest
 		}
+	}
+
+	var de detailsErr
+	if ok := errors.As(err, &de); ok && status < 500 {
+		payload.Details = de.Details()
 	}
 
 	w.WriteHeader(status)

--- a/flow/api/serde/error_test.go
+++ b/flow/api/serde/error_test.go
@@ -1,0 +1,45 @@
+package serde
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestErrorIncludesClientDetails(t *testing.T) {
+	details := []map[string]string{{"path": "$[0]", "message": "is invalid"}}
+	err := WithDetails(
+		details,
+		WithEnum(
+			ValidationFailed,
+			WithStatus(http.StatusBadRequest, errors.New("invalid payload")),
+		),
+	)
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/admin", nil)
+
+	Error(response, request, err)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
+	}
+	body := response.Body.String()
+	if !strings.Contains(body, `"error":"validation_failed"`) ||
+		!strings.Contains(body, `"path":"$[0]"`) {
+		t.Fatalf("response does not contain validation details: %s", body)
+	}
+}
+
+func TestErrorOmitsDetailsForServerErrors(t *testing.T) {
+	err := WithDetails("sensitive", errors.New("database failed"))
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/admin", nil)
+
+	Error(response, request, err)
+
+	if strings.Contains(response.Body.String(), "sensitive") {
+		t.Fatalf("server error leaked details: %s", response.Body.String())
+	}
+}

--- a/flow/common/env/env.go
+++ b/flow/common/env/env.go
@@ -12,7 +12,8 @@ import (
 type Environment struct {
 	ApiPort string `from:"API_PORT"`
 
-	JwtKey []byte `from:"HASURA_GRAPHQL_JWT_KEY"`
+	JwtKey            []byte `from:"HASURA_GRAPHQL_JWT_KEY"`
+	HasuraAdminSecret string `from:"HASURA_GRAPHQL_ADMIN_SECRET"`
 
 	PostgresDatabase string `from:"POSTGRES_DB"`
 	PostgresHost     string `from:"POSTGRES_HOST"`
@@ -20,9 +21,9 @@ type Environment struct {
 	PostgresPort     string `from:"POSTGRES_PORT"`
 	PostgresUser     string `from:"POSTGRES_USER"`
 
-	RunMode		string `from:"RUN_MODE"`
+	RunMode string `from:"RUN_MODE"`
 
-	UWApiKeyv3	string `from:"UW_API_KEY_V3"`
+	UWApiKeyv3 string `from:"UW_API_KEY_V3"`
 }
 
 // To avoid mind-numbing boilerplate, use reflection.

--- a/hasura/migrations/default/1782057600000_ingest_prof_teaches/down.sql
+++ b/hasura/migrations/default/1782057600000_ingest_prof_teaches/down.sql
@@ -1,0 +1,178 @@
+BEGIN;
+
+-- Drop the Quest ingestion table and restore prof_teaches_course to its
+-- section_meeting-only definition. The dependent search chain is recreated
+-- verbatim.
+DROP TRIGGER refresh_section_meeting ON section_meeting;
+DROP TRIGGER IF EXISTS refresh_course_section ON course_section;
+DROP TRIGGER IF EXISTS refresh_prof_teaches_course_ingestion ON public.prof_teaches_course_ingestion;
+
+DROP FUNCTION refresh_section_meeting_views;
+DROP FUNCTION search_courses;
+DROP FUNCTION search_profs;
+
+DROP VIEW course_search_index;
+DROP MATERIALIZED VIEW materialized.course_search_index;
+DROP VIEW prof_search_index;
+DROP MATERIALIZED VIEW materialized.prof_search_index;
+DROP VIEW prof_teaches_course;
+DROP MATERIALIZED VIEW materialized.prof_teaches_course;
+
+DROP TABLE public.prof_teaches_course_ingestion;
+
+CREATE MATERIALIZED VIEW materialized.prof_teaches_course AS
+SELECT DISTINCT cs.course_id, sm.prof_id
+FROM course_section cs
+  JOIN section_meeting sm ON sm.section_id = cs.id
+WHERE sm.prof_id IS NOT NULL;
+
+CREATE VIEW prof_teaches_course AS
+SELECT * FROM materialized.prof_teaches_course;
+
+CREATE MATERIALIZED VIEW materialized.course_search_index AS
+SELECT
+  course.id                                   AS course_id,
+  course.code                                 AS code,
+  course.name                                 AS name,
+  ARRAY_TO_STRING(REGEXP_MATCHES(
+    course.code, '^(.+?)[0-9]'), '')          AS course_letters,
+  materialized.course_rating.filled_count     AS ratings,
+  materialized.course_rating.liked            AS liked,
+  materialized.course_rating.easy             AS easy,
+  materialized.course_rating.useful           AS useful,
+  COALESCE(ARRAY_AGG(DISTINCT course_section.term_id)
+    FILTER (WHERE course_section.term_id IS NOT NULL),
+    ARRAY[]::INT[])                           AS terms,
+  COALESCE(ARRAY_AGG(DISTINCT course_section.term_id)
+    FILTER (WHERE course_section.term_id IS NOT NULL
+            AND course_section.enrollment_total < course_section.enrollment_capacity),
+    ARRAY[]::INT[])                           AS terms_with_seats,
+  COALESCE(ARRAY_AGG(DISTINCT materialized.prof_teaches_course.prof_id)
+    FILTER (WHERE materialized.prof_teaches_course.prof_id IS NOT NULL),
+    ARRAY[]::INT[])                           AS prof_ids,
+  COALESCE(ARRAY_AGG(DISTINCT course_section.term_id)
+    FILTER (WHERE course_section.is_online = TRUE),
+    ARRAY[]::INT[])                           AS terms_with_online_sections,
+  COALESCE(TRIM(course.prereqs), '') != '' OR
+    COALESCE(ARRAY_LENGTH(ARRAY_AGG(
+      DISTINCT course_prerequisite.course_id)
+      FILTER (WHERE course_prerequisite.course_id IS NOT NULL),
+    1), 0) > 0                                AS has_prereqs,
+  to_tsvector('simple', course.code) ||
+  to_tsvector('simple', course.name) ||
+  to_tsvector('simple', ARRAY_TO_STRING(REGEXP_MATCHES(course.code,
+    '^[a-z|A-Z]+([0-9]+[a-z|A-Z]*)'), ''))    AS document
+FROM course
+  LEFT JOIN course_prerequisite ON course_prerequisite.course_id = course.id
+  LEFT JOIN course_section ON course_section.course_id = course.id
+  LEFT JOIN materialized.prof_teaches_course ON materialized.prof_teaches_course.course_id = course.id
+  LEFT JOIN materialized.course_rating ON materialized.course_rating.course_id = course.id
+GROUP BY course.id, ratings, liked, easy, useful;
+
+CREATE VIEW course_search_index AS
+SELECT * FROM materialized.course_search_index;
+
+CREATE MATERIALIZED VIEW materialized.prof_search_index AS
+SELECT
+  prof.id                                     AS prof_id,
+  prof.name                                   AS name,
+  prof.code                                   AS code,
+  materialized.prof_rating.filled_count       AS ratings,
+  materialized.prof_rating.liked              AS liked,
+  materialized.prof_rating.clear              AS clear,
+  materialized.prof_rating.engaging           AS engaging,
+  COALESCE(ARRAY_AGG(DISTINCT materialized.prof_teaches_course.course_id)
+    FILTER (WHERE materialized.prof_teaches_course.course_id IS NOT NULL),
+    ARRAY[]::INT[])                           AS course_ids,
+  COALESCE(ARRAY(SELECT course.code FROM
+    unnest(ARRAY_AGG(DISTINCT materialized.prof_teaches_course.course_id)
+    FILTER (WHERE materialized.prof_teaches_course.course_id IS NOT NULL)) course_id
+    LEFT JOIN course on course.id = course_id),
+    ARRAY[]::TEXT[])                          AS course_codes,
+  to_tsvector('simple', prof.name)            AS document
+FROM prof
+  LEFT JOIN materialized.prof_teaches_course ON materialized.prof_teaches_course.prof_id = prof.id
+  LEFT JOIN materialized.prof_rating ON materialized.prof_rating.prof_id = prof.id
+GROUP BY prof.id, ratings, liked, clear, engaging;
+
+CREATE VIEW prof_search_index AS
+SELECT * FROM materialized.prof_search_index;
+
+CREATE INDEX prof_teaches_course_course_id_fkey
+  ON materialized.prof_teaches_course(course_id);
+CREATE INDEX prof_teaches_course_prof_id_fkey
+  ON materialized.prof_teaches_course(prof_id);
+CREATE INDEX idx_course_search
+  ON materialized.course_search_index USING GIN(document);
+CREATE INDEX idx_prof_search
+  ON materialized.prof_search_index USING GIN(document);
+
+CREATE FUNCTION refresh_section_meeting_views()
+RETURNS TRIGGER AS $$
+  BEGIN
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.course_rating;';
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.prof_rating;';
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.prof_teaches_course;';
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.course_search_index;';
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.prof_search_index;';
+    RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION search_courses(query TEXT, code_only BOOLEAN)
+RETURNS SETOF course_search_index AS $$
+  BEGIN
+    IF code_only THEN
+      RETURN QUERY
+      SELECT * FROM course_search_index
+        WHERE course_letters ILIKE query
+      ORDER BY ratings DESC;
+    ELSE
+      RETURN QUERY
+      SELECT * FROM course_search_index
+        WHERE document @@ to_tsquery('simple', query)
+      UNION
+      SELECT DISTINCT * FROM (SELECT unnest(course_ids) AS course_id
+        FROM prof_search_index
+        WHERE document @@ to_tsquery('simple', query)) prof_courses
+        LEFT JOIN course_search_index USING (course_id)
+      ORDER BY ratings DESC;
+    END IF;
+  END
+$$ LANGUAGE plpgsql STABLE;
+
+CREATE FUNCTION search_profs(query TEXT, code_only BOOLEAN)
+RETURNS SETOF prof_search_index AS $$
+  BEGIN
+    IF code_only THEN
+      RETURN QUERY
+      SELECT DISTINCT * FROM (SELECT unnest(prof_ids) AS prof_id
+        FROM course_search_index
+        WHERE course_letters ILIKE query) course_profs
+        LEFT JOIN prof_search_index USING (prof_id)
+      ORDER BY ratings DESC;
+    ELSE
+      RETURN QUERY
+      SELECT * FROM prof_search_index
+        WHERE document @@ to_tsquery('simple', query)
+      UNION
+      SELECT DISTINCT * FROM (SELECT unnest(prof_ids) AS prof_id
+        FROM course_search_index
+        WHERE document @@ to_tsquery('simple', query)) course_profs
+        LEFT JOIN prof_search_index USING (prof_id)
+      ORDER BY ratings DESC;
+    END IF;
+  END;
+$$ LANGUAGE plpgsql STABLE;
+
+CREATE TRIGGER refresh_section_meeting
+AFTER INSERT OR UPDATE OR DELETE ON section_meeting
+FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_section_meeting_views();
+
+CREATE TRIGGER refresh_course_section
+AFTER INSERT OR UPDATE OR DELETE ON course_section
+FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_section_meeting_views();
+
+COMMIT;

--- a/hasura/migrations/default/1782057600000_ingest_prof_teaches/up.sql
+++ b/hasura/migrations/default/1782057600000_ingest_prof_teaches/up.sql
@@ -1,0 +1,230 @@
+BEGIN;
+
+-- Surface validated Quest professor-course associations in every search path by
+-- adding an ingestion table and folding it into prof_teaches_course.
+--
+-- prof_teaches_course can't be redefined in place: course_search_index,
+-- prof_search_index, search_courses, and search_profs all depend on it. So we
+-- drop that whole dependent chain, redefine prof_teaches_course, then recreate
+-- the dependents VERBATIM. Only the three blocks marked CHANGED below are new;
+-- everything marked UNCHANGED is an identical rebuild of the current schema.
+
+-- Tear down the dependent chain (recreated unchanged near the bottom).
+DROP TRIGGER refresh_section_meeting ON section_meeting;
+DROP TRIGGER IF EXISTS refresh_course_section ON course_section;
+
+DROP FUNCTION refresh_section_meeting_views;
+DROP FUNCTION search_courses;
+DROP FUNCTION search_profs;
+
+DROP VIEW course_search_index;
+DROP MATERIALIZED VIEW materialized.course_search_index;
+DROP VIEW prof_search_index;
+DROP MATERIALIZED VIEW materialized.prof_search_index;
+DROP VIEW prof_teaches_course;
+DROP MATERIALIZED VIEW materialized.prof_teaches_course;
+
+-- === CHANGED: new table holding validated Quest associations ===
+CREATE TABLE public.prof_teaches_course_ingestion (
+  term_code INT NOT NULL
+    REFERENCES public.term(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  term_name TEXT NOT NULL
+    CONSTRAINT prof_teaches_course_ingestion_term_name_length
+      CHECK (LENGTH(term_name) BETWEEN 1 AND 256),
+  course_id INT NOT NULL
+    REFERENCES public.course(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  course_code TEXT NOT NULL
+    CONSTRAINT prof_teaches_course_ingestion_course_code_length
+      CHECK (LENGTH(course_code) BETWEEN 1 AND 16),
+  instructor TEXT NOT NULL
+    CONSTRAINT prof_teaches_course_ingestion_instructor_length
+      CHECK (LENGTH(instructor) BETWEEN 1 AND 256),
+  prof_id INT NOT NULL
+    REFERENCES public.prof(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  scraped_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT prof_teaches_course_ingestion_pkey
+    PRIMARY KEY (term_code, course_id, instructor)
+);
+
+CREATE INDEX prof_teaches_course_ingestion_prof_id_fkey
+  ON public.prof_teaches_course_ingestion(prof_id);
+
+-- === CHANGED: was section_meeting only; now UNIONs in the scraped table ===
+CREATE MATERIALIZED VIEW materialized.prof_teaches_course AS
+SELECT DISTINCT course_id, prof_id
+FROM (
+  SELECT cs.course_id, sm.prof_id
+  FROM course_section cs
+    JOIN section_meeting sm ON sm.section_id = cs.id
+  WHERE sm.prof_id IS NOT NULL
+
+  UNION
+
+  SELECT course_id, prof_id
+  FROM public.prof_teaches_course_ingestion
+) teaching;
+
+CREATE VIEW prof_teaches_course AS
+SELECT * FROM materialized.prof_teaches_course;
+
+-- === UNCHANGED below: dependents recreated verbatim from the current schema ===
+CREATE MATERIALIZED VIEW materialized.course_search_index AS
+SELECT
+  course.id                                   AS course_id,
+  course.code                                 AS code,
+  course.name                                 AS name,
+  ARRAY_TO_STRING(REGEXP_MATCHES(
+    course.code, '^(.+?)[0-9]'), '')          AS course_letters,
+  materialized.course_rating.filled_count     AS ratings,
+  materialized.course_rating.liked            AS liked,
+  materialized.course_rating.easy             AS easy,
+  materialized.course_rating.useful           AS useful,
+  COALESCE(ARRAY_AGG(DISTINCT course_section.term_id)
+    FILTER (WHERE course_section.term_id IS NOT NULL),
+    ARRAY[]::INT[])                           AS terms,
+  COALESCE(ARRAY_AGG(DISTINCT course_section.term_id)
+    FILTER (WHERE course_section.term_id IS NOT NULL
+            AND course_section.enrollment_total < course_section.enrollment_capacity),
+    ARRAY[]::INT[])                           AS terms_with_seats,
+  COALESCE(ARRAY_AGG(DISTINCT materialized.prof_teaches_course.prof_id)
+    FILTER (WHERE materialized.prof_teaches_course.prof_id IS NOT NULL),
+    ARRAY[]::INT[])                           AS prof_ids,
+  COALESCE(ARRAY_AGG(DISTINCT course_section.term_id)
+    FILTER (WHERE course_section.is_online = TRUE),
+    ARRAY[]::INT[])                           AS terms_with_online_sections,
+  COALESCE(TRIM(course.prereqs), '') != '' OR
+    COALESCE(ARRAY_LENGTH(ARRAY_AGG(
+      DISTINCT course_prerequisite.course_id)
+      FILTER (WHERE course_prerequisite.course_id IS NOT NULL),
+    1), 0) > 0                                AS has_prereqs,
+  to_tsvector('simple', course.code) ||
+  to_tsvector('simple', course.name) ||
+  to_tsvector('simple', ARRAY_TO_STRING(REGEXP_MATCHES(course.code,
+    '^[a-z|A-Z]+([0-9]+[a-z|A-Z]*)'), ''))    AS document
+FROM course
+  LEFT JOIN course_prerequisite ON course_prerequisite.course_id = course.id
+  LEFT JOIN course_section ON course_section.course_id = course.id
+  LEFT JOIN materialized.prof_teaches_course ON materialized.prof_teaches_course.course_id = course.id
+  LEFT JOIN materialized.course_rating ON materialized.course_rating.course_id = course.id
+GROUP BY course.id, ratings, liked, easy, useful;
+
+CREATE VIEW course_search_index AS
+SELECT * FROM materialized.course_search_index;
+
+CREATE MATERIALIZED VIEW materialized.prof_search_index AS
+SELECT
+  prof.id                                     AS prof_id,
+  prof.name                                   AS name,
+  prof.code                                   AS code,
+  materialized.prof_rating.filled_count       AS ratings,
+  materialized.prof_rating.liked              AS liked,
+  materialized.prof_rating.clear              AS clear,
+  materialized.prof_rating.engaging           AS engaging,
+  COALESCE(ARRAY_AGG(DISTINCT materialized.prof_teaches_course.course_id)
+    FILTER (WHERE materialized.prof_teaches_course.course_id IS NOT NULL),
+    ARRAY[]::INT[])                           AS course_ids,
+  COALESCE(ARRAY(SELECT course.code FROM
+    unnest(ARRAY_AGG(DISTINCT materialized.prof_teaches_course.course_id)
+    FILTER (WHERE materialized.prof_teaches_course.course_id IS NOT NULL)) course_id
+    LEFT JOIN course on course.id = course_id),
+    ARRAY[]::TEXT[])                          AS course_codes,
+  to_tsvector('simple', prof.name)            AS document
+FROM prof
+  LEFT JOIN materialized.prof_teaches_course ON materialized.prof_teaches_course.prof_id = prof.id
+  LEFT JOIN materialized.prof_rating ON materialized.prof_rating.prof_id = prof.id
+GROUP BY prof.id, ratings, liked, clear, engaging;
+
+CREATE VIEW prof_search_index AS
+SELECT * FROM materialized.prof_search_index;
+
+CREATE INDEX prof_teaches_course_course_id_fkey
+  ON materialized.prof_teaches_course(course_id);
+CREATE INDEX prof_teaches_course_prof_id_fkey
+  ON materialized.prof_teaches_course(prof_id);
+CREATE INDEX idx_course_search
+  ON materialized.course_search_index USING GIN(document);
+CREATE INDEX idx_prof_search
+  ON materialized.prof_search_index USING GIN(document);
+
+CREATE FUNCTION refresh_section_meeting_views()
+RETURNS TRIGGER AS $$
+  BEGIN
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.course_rating;';
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.prof_rating;';
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.prof_teaches_course;';
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.course_search_index;';
+    EXECUTE 'REFRESH MATERIALIZED VIEW materialized.prof_search_index;';
+    RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION search_courses(query TEXT, code_only BOOLEAN)
+RETURNS SETOF course_search_index AS $$
+  BEGIN
+    IF code_only THEN
+      RETURN QUERY
+      SELECT * FROM course_search_index
+        WHERE course_letters ILIKE query
+      ORDER BY ratings DESC;
+    ELSE
+      RETURN QUERY
+      SELECT * FROM course_search_index
+        WHERE document @@ to_tsquery('simple', query)
+      UNION
+      SELECT DISTINCT * FROM (SELECT unnest(course_ids) AS course_id
+        FROM prof_search_index
+        WHERE document @@ to_tsquery('simple', query)) prof_courses
+        LEFT JOIN course_search_index USING (course_id)
+      ORDER BY ratings DESC;
+    END IF;
+  END
+$$ LANGUAGE plpgsql STABLE;
+
+CREATE FUNCTION search_profs(query TEXT, code_only BOOLEAN)
+RETURNS SETOF prof_search_index AS $$
+  BEGIN
+    IF code_only THEN
+      RETURN QUERY
+      SELECT DISTINCT * FROM (SELECT unnest(prof_ids) AS prof_id
+        FROM course_search_index
+        WHERE course_letters ILIKE query) course_profs
+        LEFT JOIN prof_search_index USING (prof_id)
+      ORDER BY ratings DESC;
+    ELSE
+      RETURN QUERY
+      SELECT * FROM prof_search_index
+        WHERE document @@ to_tsquery('simple', query)
+      UNION
+      SELECT DISTINCT * FROM (SELECT unnest(prof_ids) AS prof_id
+        FROM course_search_index
+        WHERE document @@ to_tsquery('simple', query)) course_profs
+        LEFT JOIN prof_search_index USING (prof_id)
+      ORDER BY ratings DESC;
+    END IF;
+  END;
+$$ LANGUAGE plpgsql STABLE;
+
+CREATE TRIGGER refresh_section_meeting
+AFTER INSERT OR UPDATE OR DELETE ON section_meeting
+FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_section_meeting_views();
+
+CREATE TRIGGER refresh_course_section
+AFTER INSERT OR UPDATE OR DELETE ON course_section
+FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_section_meeting_views();
+
+-- === CHANGED: refresh search data after a Quest ingestion statement ===
+CREATE TRIGGER refresh_prof_teaches_course_ingestion
+AFTER INSERT OR UPDATE OR DELETE ON public.prof_teaches_course_ingestion
+FOR EACH STATEMENT
+EXECUTE PROCEDURE refresh_section_meeting_views();
+
+COMMIT;

--- a/nginx/config/site.conf
+++ b/nginx/config/site.conf
@@ -29,6 +29,13 @@ server {
     listen $NGINX_HTTPS_PORT ssl http2;
     server_name $DOMAIN;
 
+    # Administrative API routes are only reachable directly from the backend
+    # network (for example, over an SSH tunnel to localhost:8081). Do not expose
+    # them through the public reverse proxy.
+    location /api/admin/ {
+      return 404;
+    }
+
     location /api/ {
       # The trailing slash is crucial:
       # Only with it does Nginx implicitly rewrite the request string as needed.


### PR DESCRIPTION
## Summary

- add a server-authenticated `POST /admin/prof-teaches/ingest` endpoint for the Quest scraper's `prof_teaches.json`
- validate the full payload and referenced term/course IDs before any write, with path-specific client errors and in-file deduplication
- create or resolve professors through UWFlow's existing professor-code/remap identity, then idempotently upsert term-aware scrape provenance
- fold ingested associations into the materialized professor/course relationship and refresh both search indexes
- keep every `/api/admin/` route off the public Nginx proxy while retaining header authentication on the private API
- include reversible migrations, focused tests, and operator documentation

This consolidates the useful behavior from #194 and the older Flow-42 ingestion branches into one implementation. It intentionally drops the obsolete fuzzy-match review files, generated match dumps, and duplicated upload endpoint.

## Verification

- `CGO_CPPFLAGS="-I/opt/homebrew/Cellar/poppler/25.03.0/include" CGO_LDFLAGS="-L/opt/homebrew/Cellar/poppler/25.03.0/lib -lpoppler-cpp" GOCACHE=/private/tmp/uwflow-prof-ingest-go-cache go test ./...`
- same environment with `go vet ./...`
- applied every migration from an empty PostgreSQL 15 database, then rolled back and reapplied the new migration
- uploaded the real 3-term, 6,172-row scrape: 6,172 provenance rows became 5,414 distinct search links across 2,073 professors and 3,521 courses
- repeated the same upload and received `records_written: 0`
- verified all 2,073 professors and all 3,521 courses have associations in the materialized indexes and `GET /data/search`
- rendered the Nginx template and passed `nginx -t`
- `git diff --check`