### PR TITLE
feat(auth): require email verification for new signups

### DIFF
--- a/flow/api/auth/email.go
+++ b/flow/api/auth/email.go
@@ -17,14 +17,15 @@ type emailLoginRequest struct {
 }
 
 const selectUserQuery = `
-SELECT user_id, password_hash FROM secret.user_email WHERE email = $1
+SELECT user_id, password_hash, verified FROM secret.user_email WHERE email = $1
 `
 
 func loginEmail(tx *db.Tx, email string, password []byte) (*authResponse, error) {
 	var response authResponse
 	var hash []byte
+	var verified bool
 
-	err := tx.QueryRow(selectUserQuery, email).Scan(&response.UserId, &hash)
+	err := tx.QueryRow(selectUserQuery, email).Scan(&response.UserId, &hash, &verified)
 	if err != nil {
 		return nil, serde.WithEnum(serde.EmailNotRegistered, fmt.Errorf("email not registered: %s: %v", email, err))
 	}
@@ -32,6 +33,10 @@ func loginEmail(tx *db.Tx, email string, password []byte) (*authResponse, error)
 	err = bcrypt.CompareHashAndPassword(hash, password)
 	if err != nil {
 		return nil, serde.WithEnum(serde.EmailWrongPassword, fmt.Errorf("comparing hash and password: %w", err))
+	}
+
+	if !verified {
+		return nil, serde.WithEnum(serde.EmailNotVerified, fmt.Errorf("email not verified: %s", email))
 	}
 
 	response.Token, err = serde.NewSignedJwt(response.UserId)
@@ -62,7 +67,7 @@ func LoginEmail(tx *db.Tx, r *http.Request) (interface{}, error) {
 }
 
 const insertUserEmailQuery = `
-INSERT INTO secret.user_email(user_id, email, password_hash) VALUES ($1, $2, $3)
+INSERT INTO secret.user_email(user_id, email, password_hash, verified) VALUES ($1, $2, $3, FALSE)
 `
 
 func registerEmail(tx *db.Tx, user *userInfo, password []byte) (*authResponse, error) {
@@ -80,6 +85,13 @@ func registerEmail(tx *db.Tx, user *userInfo, password []byte) (*authResponse, e
 	if err != nil {
 		return nil, serde.WithEnum(serde.EmailTaken, fmt.Errorf("inserting user_email: %w", err))
 	}
+
+	// New email accounts must verify before they can log in. Queue a code and
+	// withhold the token so the client cannot proceed until VerifyEmail succeeds.
+	if err := writeVerifyCode(tx, response.UserId); err != nil {
+		return nil, err
+	}
+	response.Token = ""
 
 	return response, nil
 }

--- a/flow/api/auth/verify.go
+++ b/flow/api/auth/verify.go
@@ -1,0 +1,125 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"flow/api/serde"
+	"flow/common/db"
+	"flow/common/util/random"
+)
+
+const upsertEmailVerifyQuery = `
+INSERT INTO queue.email_verify(user_id, secret_key, expiry)
+VALUES ($1, $2, $3)
+ON CONFLICT (user_id) DO UPDATE SET secret_key = EXCLUDED.secret_key, expiry = EXCLUDED.expiry, created_at = NOW(), seen_at = NULL
+`
+
+// writeVerifyCode generates a fresh verification code for the user and queues
+// the verification email. The queue.email_verify INSERT trigger notifies the
+// mail worker, which sends the code. Shared by register and resend.
+func writeVerifyCode(tx *db.Tx, userId int) error {
+	key, err := random.String(verifyKeyLength, random.AllLetters)
+	if err != nil {
+		return fmt.Errorf("generating verify key: %w", err)
+	}
+
+	expiry := time.Now().Add(time.Hour)
+	if _, err := tx.Exec(upsertEmailVerifyQuery, userId, key, expiry); err != nil {
+		return fmt.Errorf("writing email_verify: %w", err)
+	}
+
+	return nil
+}
+
+type sendVerifyEmailRequest struct {
+	Email string `json:"email"`
+}
+
+// SendVerifyEmail (re)sends a verification code to a registered email. Used to
+// resend on signup and when an unverified user tries to log in.
+func SendVerifyEmail(tx *db.Tx, r *http.Request) error {
+	var body sendVerifyEmailRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return serde.WithStatus(http.StatusBadRequest, fmt.Errorf("malformed JSON: %w", err))
+	}
+
+	if body.Email == "" {
+		return serde.WithStatus(http.StatusBadRequest, fmt.Errorf("empty email"))
+	}
+
+	var userId int
+	err := tx.QueryRow(selectIdQuery, body.Email).Scan(&userId)
+	if err != nil {
+		return serde.WithStatus(
+			http.StatusBadRequest,
+			serde.WithEnum(serde.EmailNotRegistered, fmt.Errorf("email not registered")),
+		)
+	}
+
+	return writeVerifyCode(tx, userId)
+}
+
+const selectVerifyCodeQuery = `
+SELECT user_id, expiry FROM queue.email_verify WHERE secret_key = $1
+`
+
+const markVerifiedQuery = `
+UPDATE secret.user_email SET verified = TRUE WHERE user_id = $1
+`
+
+const deleteVerifyCodeQuery = `
+DELETE FROM queue.email_verify WHERE secret_key = $1
+`
+
+type verifyEmailRequest struct {
+	Key string `json:"key"`
+}
+
+// VerifyEmail consumes a verification code, marks the account verified, and
+// returns a signed JWT so the now-verified user is logged in.
+func VerifyEmail(tx *db.Tx, r *http.Request) (interface{}, error) {
+	var body verifyEmailRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return nil, serde.WithStatus(http.StatusBadRequest, fmt.Errorf("malformed JSON: %w", err))
+	}
+
+	if body.Key == "" {
+		return nil, serde.WithStatus(http.StatusBadRequest, fmt.Errorf("no key"))
+	}
+
+	var response authResponse
+	var expiry time.Time
+	err := tx.QueryRow(selectVerifyCodeQuery, body.Key).Scan(&response.UserId, &expiry)
+	if err != nil {
+		return nil, serde.WithStatus(
+			http.StatusForbidden,
+			serde.WithEnum(serde.InvalidVerifyKey, fmt.Errorf("key %s does not exist: %w", body.Key, err)),
+		)
+	}
+
+	if !expiry.After(time.Now()) {
+		return nil, serde.WithStatus(
+			http.StatusForbidden,
+			serde.WithEnum(serde.InvalidVerifyKey, fmt.Errorf("key expired at %v", expiry)),
+		)
+	}
+
+	if _, err := tx.Exec(markVerifiedQuery, response.UserId); err != nil {
+		return nil, fmt.Errorf("marking verified: %w", err)
+	}
+
+	if _, err := tx.Exec(deleteVerifyCodeQuery, body.Key); err != nil {
+		return nil, fmt.Errorf("deleting verify code: %w", err)
+	}
+
+	response.Token, err = serde.NewSignedJwt(response.UserId)
+	if err != nil {
+		return nil, fmt.Errorf("signing jwt: %w", err)
+	}
+	response.IsNew = true
+
+	return &response, nil
+}

--- a/flow/api/main.go
+++ b/flow/api/main.go
@@ -47,6 +47,14 @@ func setupRouter(conn *db.Conn) *chi.Mux {
 		serde.WithDbResponse(conn, auth.RegisterEmail, "email register"),
 	)
 	router.Post(
+		"/auth/email/verify/send",
+		serde.WithDbNoResponse(conn, auth.SendVerifyEmail, "email verification initiation"),
+	)
+	router.Post(
+		"/auth/email/verify",
+		serde.WithDbResponse(conn, auth.VerifyEmail, "email verification"),
+	)
+	router.Post(
 		"/auth/facebook/login",
 		serde.WithDbResponse(conn, auth.LoginFacebook, "facebook login"),
 	)

--- a/flow/api/serde/error.go
+++ b/flow/api/serde/error.go
@@ -27,6 +27,12 @@ const (
 	EmailNotRegistered = "email_not_registered"
 	// There is a user with given email, but the given password is incorrect
 	EmailWrongPassword = "email_wrong_password"
+	// Account exists but the email has not been verified yet
+	EmailNotVerified = "email_not_verified"
+
+	//// Email verification
+	// Email verification code is invalid or expired
+	InvalidVerifyKey = "invalid_verify_key"
 
 	//// Password reset
 	// Password reset key is invalid or expired

--- a/flow/email/format/data.go
+++ b/flow/email/format/data.go
@@ -30,6 +30,17 @@ type ResetItem struct {
 // RowID implements QueueItem.
 func (it *ResetItem) RowID() int { return it.ID }
 
+// VerifyItem is a row of queue.email_verify.
+type VerifyItem struct {
+	ID        int
+	Email     string
+	UserName  string
+	SecretKey string
+}
+
+// RowID implements QueueItem.
+func (it *VerifyItem) RowID() int { return it.ID }
+
 // SubscribedItem is a row of queue.section_subscribed.
 type SubscribedItem struct {
 	ID         int

--- a/flow/email/format/format.go
+++ b/flow/email/format/format.go
@@ -27,6 +27,25 @@ func (item *ResetItem) Message() (Message, error) {
 }
 
 // Message implements QueueItem.
+func (item *VerifyItem) Message() (Message, error) {
+	var (
+		buf bytes.Buffer
+		msg Message
+	)
+
+	if err := verifyTemplate.Execute(&buf, item); err != nil {
+		return msg, err
+	}
+
+	msg = Message{
+		Body:    buf.Bytes(),
+		Subject: "Verify your email on UW Flow",
+		To:      item.Email,
+	}
+	return msg, nil
+}
+
+// Message implements QueueItem.
 func (item *SubscribedItem) Message() (Message, error) {
 	var (
 		buf bytes.Buffer

--- a/flow/email/format/format_test.go
+++ b/flow/email/format/format_test.go
@@ -1,0 +1,37 @@
+package format
+
+import (
+	"strings"
+	"testing"
+)
+
+// Guards the fragile bit of the verification email: the template must render
+// the recipient's code and carry the verification subject. Fails if a template
+// field is renamed or the subject drifts.
+func TestVerifyItemMessage(t *testing.T) {
+	item := &VerifyItem{
+		ID:        1,
+		Email:     "feridun@uwflow.com",
+		UserName:  "Feridun",
+		SecretKey: "ABC123",
+	}
+
+	msg, err := item.Message()
+	if err != nil {
+		t.Fatalf("rendering verify message: %v", err)
+	}
+
+	if msg.To != item.Email {
+		t.Errorf("To = %q, want %q", msg.To, item.Email)
+	}
+	if !strings.Contains(msg.Subject, "Verify") {
+		t.Errorf("Subject = %q, want it to mention verification", msg.Subject)
+	}
+	body := string(msg.Body)
+	if !strings.Contains(body, item.SecretKey) {
+		t.Errorf("body missing verification code %q", item.SecretKey)
+	}
+	if !strings.Contains(body, item.UserName) {
+		t.Errorf("body missing user name %q", item.UserName)
+	}
+}

--- a/flow/email/format/template.go
+++ b/flow/email/format/template.go
@@ -37,6 +37,13 @@ const resetText = `
 				UW Flow
 `
 
+const verifyText = `
+				Hi {{.UserName}},<br /><br />
+				Welcome to UW Flow! Your email verification code is {{.SecretKey}}. Enter it back on Flow to finish setting up your account.<br /><br />
+				Cheers,<br />
+				UW Flow
+`
+
 const subscribedText = `
 				Hi {{.UserName}},<br /><br />
 				You subscribed to one or more sections in {{.CourseCode}}.<br /><br />
@@ -67,6 +74,7 @@ var manyVacatedText = `
 
 var (
 	resetTemplate       = template.New("reset")
+	verifyTemplate      = template.New("verify")
 	subscribedTemplate  = template.New("subscribed")
 	oneVacatedTemplate  = template.New("one_vacated")
 	manyVacatedTemplate = template.New("many_vacated")
@@ -75,6 +83,9 @@ var (
 func init() {
 	if _, err := resetTemplate.Parse(prologue + resetText + epilogue); err != nil {
 		log.Fatalf("Error: parse reset template: %v", err)
+	}
+	if _, err := verifyTemplate.Parse(prologue + verifyText + epilogue); err != nil {
+		log.Fatalf("Error: parse verify template: %v", err)
 	}
 	if _, err := subscribedTemplate.Parse(prologue + subscribedText + epilogue); err != nil {
 		log.Fatalf("Error: parse subscribed template: %v", err)

--- a/flow/email/listen.go
+++ b/flow/email/listen.go
@@ -14,6 +14,8 @@ func dispatch(ctx context.Context, tx pgx.Tx, source string) error {
 	switch source {
 	case "password_reset":
 		return process.Reset(ctx, tx)
+	case "email_verify":
+		return process.Verify(ctx, tx)
 	case "section_subscribed":
 		return process.Subscribed(ctx, tx)
 	case "section_vacated":

--- a/flow/email/process/info.go
+++ b/flow/email/process/info.go
@@ -21,6 +21,11 @@ var resetInfo = queueInfo{
 	writeQuery: `UPDATE queue.password_reset SET seen_at = NOW() WHERE user_id = $1`,
 }
 
+var verifyInfo = queueInfo{
+	scanFunc:   scanVerify,
+	writeQuery: `UPDATE queue.email_verify SET seen_at = NOW() WHERE user_id = $1`,
+}
+
 var subscribedInfo = queueInfo{
 	scanFunc:   scanSubscribed,
 	writeQuery: `UPDATE queue.section_subscribed SET seen_at = NOW() WHERE id = $1`,

--- a/flow/email/process/process.go
+++ b/flow/email/process/process.go
@@ -40,6 +40,11 @@ func Reset(ctx context.Context, tx pgx.Tx) error {
 	return process(ctx, tx, resetInfo)
 }
 
+// Verify processes all unseen items in queue.email_verify.
+func Verify(ctx context.Context, tx pgx.Tx) error {
+	return process(ctx, tx, verifyInfo)
+}
+
 // Subscribed processes all unseen items in queue.section_subscribed.
 func Subscribed(ctx context.Context, tx pgx.Tx) error {
 	return process(ctx, tx, subscribedInfo)

--- a/flow/email/process/scan.go
+++ b/flow/email/process/scan.go
@@ -37,6 +37,33 @@ WHERE pr.seen_at is NULL
 	return items, nil
 }
 
+func scanVerify(ctx context.Context, tx pgx.Tx) ([]format.QueueItem, error) {
+	var items []format.QueueItem
+
+	const query = `
+SELECT ev.user_id, u.email, u.first_name, ev.secret_key
+FROM queue.email_verify ev
+  JOIN "user" u ON u.id = ev.user_id
+WHERE ev.seen_at is NULL
+`
+
+	rows, err := tx.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("loading rows: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		item := new(format.VerifyItem)
+		if err := rows.Scan(&item.ID, &item.Email, &item.UserName, &item.SecretKey); err != nil {
+			return nil, fmt.Errorf("scanning row: %w", err)
+		}
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
 func scanSubscribed(ctx context.Context, tx pgx.Tx) ([]format.QueueItem, error) {
 	var items []format.QueueItem
 

--- a/hasura/migrations/default/1782094648000_email_verification/down.sql
+++ b/hasura/migrations/default/1782094648000_email_verification/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE queue.email_verify;
+ALTER TABLE secret.user_email DROP COLUMN verified;

--- a/hasura/migrations/default/1782094648000_email_verification/up.sql
+++ b/hasura/migrations/default/1782094648000_email_verification/up.sql
@@ -1,0 +1,22 @@
+-- Email verification for new email/password signups.
+-- Existing accounts default to verified = TRUE so they are not locked out;
+-- new registrations insert verified = FALSE (see flow/api/auth/email.go).
+ALTER TABLE secret.user_email
+  ADD COLUMN verified BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Mirrors queue.password_reset: one pending code per user, emailed by the
+-- mail worker via the sendmail_notify('email_verify') trigger.
+CREATE TABLE queue.email_verify(
+    user_id INT PRIMARY KEY
+      REFERENCES "user"(id)
+      ON UPDATE CASCADE
+      ON DELETE CASCADE,
+    secret_key TEXT NOT NULL
+      CONSTRAINT email_verify_key_length CHECK (LENGTH(secret_key) = 6),
+    expiry TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    seen_at TIMESTAMPTZ DEFAULT NULL
+);
+
+CREATE TRIGGER notify_email_verify AFTER INSERT ON queue.email_verify
+FOR EACH STATEMENT EXECUTE PROCEDURE sendmail_notify('email_verify');


### PR DESCRIPTION
## What

Adds email verification to the email/password signup flow, mirroring the existing password-reset machinery. New accounts are created **unverified** and cannot log in until they enter a 6-character code emailed to them.

## Changes

- **Migration** (`1782094648000_email_verification`): adds `queue.email_verify` (one pending code per user) with a `sendmail_notify('email_verify')` trigger, plus a `verified` column on `secret.user_email`. Existing accounts default to `verified = TRUE` so nobody is locked out.
- **Auth** (`flow/api/auth`): `register` now inserts `verified = FALSE`, queues a code, and **withholds the JWT**. New `POST /auth/email/verify` (consumes code → marks verified → returns JWT) and `POST /auth/email/verify/send` (resend). `login` rejects unverified accounts with `email_not_verified`.
- **Mail worker** (`flow/email`): new `email_verify` queue case, scan, item type, and template.
- Error enums: `email_not_verified`, `invalid_verify_key`.

## Notes

- Social (Google/Facebook) logins are unaffected — they never touch `secret.user_email`.
- The pre-existing `flow/api/parse/pdf` build needs the `poppler` system lib locally; unrelated to this change. Touched packages build/vet clean and `go test ./email/format/` passes.

Pairs with the frontend PR (UWFlow/uwflow_frontend) that adds the code-entry step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)