### PR TITLE
Add script to dump the Postgres database to local disk

### DIFF
--- a/script/backup-local.sh
+++ b/script/backup-local.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Export the Postgres database to a dump file on this box's local disk.
+#
+# This is the on-server counterpart to backup-db.sh (which streams to S3).
+# Use this one when you want a dump you can scp off the box afterwards.
+# Filenames follow the convention already in ~/backup:
+#   $BACKUP_DIR/YYYY-MM-DD-pg-latest.dump
+#
+# The output is custom format (-Fc), the inverse of script/start.sh's
+# pg_restore, so a dump produced here can be fed straight back in via
+# POSTGRES_DUMP_PATH + `make setup`.
+#
+# Optional env:
+#   BACKUP_DIR   where to write (default: $HOME/backup)
+#
+# Nothing is pruned — the dump history on this box goes back years and
+# deleting any of it is a deliberate decision, not a side effect of a backup.
+#
+# pipefail matters even without a pipe here: it keeps the exit status honest
+# if this ever grows one, and a silently-truncated dump is the failure mode
+# we care most about.
+set -euo pipefail
+
+DIR="$(dirname "$(realpath "$0")")"
+. "$DIR/common.sh"
+
+# Bring backend environment variables into scope (POSTGRES_USER/DB/PORT).
+cd "$BACKEND_DIR"
+export $(grep -v '^#' .env | xargs)
+
+BACKUP_DIR="${BACKUP_DIR:-$HOME/backup}"
+mkdir -p "$BACKUP_DIR"
+
+FINAL="$BACKUP_DIR/$(date +%F)-pg-latest.dump"
+# Write to a temp name first, then rename on success, so an interrupted dump
+# never appears under the dated name and get mistaken for a good backup.
+TMP="$BACKUP_DIR/.in-progress-$(date +%F-%H%M%S).dump"
+
+# The root volume on this box is small and holds every dump ever taken, so
+# check before writing rather than discovering it mid-pg_dump.
+AVAIL_KB="$(df -Pk "$BACKUP_DIR" | awk 'NR==2 {print $4}')"
+if [ "$AVAIL_KB" -lt 204800 ]; then
+  fail "Only $((AVAIL_KB / 1024)) MiB free on $BACKUP_DIR; refusing to dump"
+elif [ "$AVAIL_KB" -lt 1048576 ]; then
+  warn "Only $((AVAIL_KB / 1024)) MiB free on $BACKUP_DIR — prune old dumps soon"
+fi
+
+echo "Dumping database '$POSTGRES_DB' to $FINAL ..."
+
+# No -t/-i on docker exec: a TTY would corrupt the binary dump on stdout.
+if $PREFIX docker exec postgres \
+     pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -p "$POSTGRES_PORT" -Fc \
+   > "$TMP"
+then
+  # Verify it's a readable archive before promoting it. pg_dump can exit 0 and
+  # still leave something unusable if the write side failed. Run the check in
+  # the container rather than on the host: the host has no postgres client
+  # tools installed, and this way the verifier always matches the dumper.
+  # No "-" for stdin: pg_restore treats it as a literal filename and fails.
+  if ! $PREFIX docker exec -i postgres pg_restore --list >/dev/null 2>&1 < "$TMP"; then
+    rm -f "$TMP"
+    fail "Dump completed but is not a valid pg archive; nothing written"
+  fi
+  mv "$TMP" "$FINAL"
+  pass "Backup written to $FINAL ($(du -h "$FINAL" | cut -f1))"
+else
+  rm -f "$TMP"
+  fail "pg_dump failed; no backup written for $(date +%F)"
+fi


### PR DESCRIPTION
## What

Adds `script/backup-local.sh`, which dumps the Postgres container to `~/backup/YYYY-MM-DD-pg-latest.dump` — the naming convention the dumps on the server already follow.

## Why

The README's instruction for getting prod data locally is "obtain it, for example, scp it from prod." There's no script behind that, so the `docker exec ... pg_dump` invocation gets retyped by hand each time.

Output is custom format (`-Fc`), so it feeds straight back into `script/start.sh`'s `pg_restore` via `POSTGRES_DUMP_PATH` + `make setup`. `POSTGRES_USER`/`DB`/`PORT` come from `.env`, so it works on any box without hardcoding `flow` vs `flow_new`.

## Notable choices

- **Temp name, rename on success.** An interrupted dump never appears under a dated name where it could be mistaken for a good backup.
- **Validates before promoting.** `pg_dump` can exit 0 and still leave an unusable file if the write side failed, so the dump is checked with `pg_restore --list` first. The check runs *inside* the container — the host has no postgres client tools installed.
- **Free-space guard.** The root volume is small and holds every dump ever taken. Fails below 200 MiB, warns below 1 GiB, rather than discovering the problem mid-dump.
- **Prunes nothing.** The dump history goes back to 2020; deleting any of it should be deliberate, not a side effect of taking a backup.

## Usage

```sh
bash script/backup-local.sh              # -> ~/backup/YYYY-MM-DD-pg-latest.dump
BACKUP_DIR=/mnt/big bash script/backup-local.sh
```

## Testing

Run against a local `postgres` container:

```
Dumping database 'flow_new' to .../2026-08-01-pg-latest.dump ...
[✔] Backup written to .../2026-08-01-pg-latest.dump ( 27M)
```

27,056,397 bytes, and `pg_restore --list` reads it back as a valid archive (309 TOC entries). In line with the 27.5 MB July dump on the server. The failure paths (invalid archive, insufficient space) are code-inspected only, not exercised.

Not yet run on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)