### PR TITLE
Persist user schedule swap plans

### DIFF
--- a/hasura/metadata/databases/default/tables/public_user_schedule_swap.yaml
+++ b/hasura/metadata/databases/default/tables/public_user_schedule_swap.yaml
@@ -1,0 +1,47 @@
+table:
+  name: user_schedule_swap
+  schema: public
+object_relationships:
+  - name: replacement_section
+    using:
+      foreign_key_constraint_on: replacement_section_id
+  - name: source_schedule
+    using:
+      foreign_key_constraint_on:
+        - user_id
+        - source_section_id
+insert_permissions:
+  - role: user
+    permission:
+      check:
+        user_id:
+          _eq: X-Hasura-User-Id
+      columns:
+        - replacement_section_id
+        - source_section_id
+        - user_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - replacement_section_id
+        - source_section_id
+        - user_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+update_permissions:
+  - role: user
+    permission:
+      columns:
+        - replacement_section_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
+      check: null
+delete_permissions:
+  - role: user
+    permission:
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id

--- a/hasura/metadata/databases/default/tables/tables.yaml
+++ b/hasura/metadata/databases/default/tables/tables.yaml
@@ -25,5 +25,6 @@
 - "!include public_user.yaml"
 - "!include public_user_course_taken.yaml"
 - "!include public_user_schedule.yaml"
+- "!include public_user_schedule_swap.yaml"
 - "!include public_user_shortlist.yaml"
 - "!include queue_section_subscribed.yaml"

--- a/hasura/migrations/default/1785705977000_add_user_schedule_swap/down.sql
+++ b/hasura/migrations/default/1785705977000_add_user_schedule_swap/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE user_schedule_swap;
+DROP FUNCTION IF EXISTS validate_user_schedule_swap_sections();

--- a/hasura/migrations/default/1785705977000_add_user_schedule_swap/up.sql
+++ b/hasura/migrations/default/1785705977000_add_user_schedule_swap/up.sql
@@ -1,0 +1,70 @@
+-- Keep the Quest-imported user_schedule unchanged. Each row below is only a
+-- planned replacement over one still-enrolled source section.
+CREATE TABLE user_schedule_swap (
+  user_id INT NOT NULL,
+  source_section_id INT NOT NULL,
+  replacement_section_id INT NOT NULL
+    REFERENCES course_section(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  CONSTRAINT user_schedule_swap_pkey
+    PRIMARY KEY (user_id, source_section_id),
+  CONSTRAINT user_schedule_swap_source_fkey
+    FOREIGN KEY (user_id, source_section_id)
+    REFERENCES user_schedule(user_id, section_id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  CONSTRAINT user_schedule_swap_changes_section
+    CHECK (source_section_id <> replacement_section_id)
+);
+
+CREATE INDEX user_schedule_swap_replacement_section_id_idx
+ON user_schedule_swap(replacement_section_id);
+
+CREATE FUNCTION validate_user_schedule_swap_sections()
+RETURNS TRIGGER AS $$
+DECLARE
+  source_term_id INT;
+  replacement_term_id INT;
+  source_section_type TEXT;
+  replacement_section_type TEXT;
+BEGIN
+  SELECT
+    source.term_id,
+    replacement.term_id,
+    SPLIT_PART(source.section_name, ' ', 1),
+    SPLIT_PART(replacement.section_name, ' ', 1)
+  INTO
+    source_term_id,
+    replacement_term_id,
+    source_section_type,
+    replacement_section_type
+  FROM course_section AS source
+  CROSS JOIN course_section AS replacement
+  WHERE source.id = NEW.source_section_id
+    AND replacement.id = NEW.replacement_section_id;
+
+  -- Missing sections are reported by the table's foreign keys.
+  IF NOT FOUND THEN
+    RETURN NEW;
+  END IF;
+
+  IF source_term_id <> replacement_term_id THEN
+    RAISE EXCEPTION 'Schedule swap sections must belong to the same term'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF source_section_type <> replacement_section_type THEN
+    RAISE EXCEPTION 'Schedule swap sections must have the same component type'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_user_schedule_swap_sections
+BEFORE INSERT OR UPDATE OF source_section_id, replacement_section_id
+ON user_schedule_swap
+FOR EACH ROW
+EXECUTE FUNCTION validate_user_schedule_swap_sections();


### PR DESCRIPTION
## Summary

- add a user_schedule_swap overlay table while keeping the Quest-imported user_schedule unchanged
- enforce one replacement per enrolled source section with foreign keys and cascade cleanup
- reject cross-term and cross-component replacements at the database boundary
- expose owner-scoped Hasura relationships and insert, select, update, and delete permissions

## Design

Each row stores user_id, source_section_id, and replacement_section_id. The composite source foreign key guarantees the source belongs to the user's original schedule; deleting that source automatically removes its saved swap.

## Verification

- applied all migrations and metadata to an isolated Postgres and Hasura instance
- verified metadata consistency and migration rollback/reapply
- verified owner reads/writes and cross-user denial
- verified source deletion cascades
- verified cross-term and cross-component replacements are rejected

## Paired frontend

- UWFlow/uwflow_frontend#297
- https://github.com/UWFlow/uwflow_frontend/pull/297