### PR TITLE
Pass --database-name to hasura migrate apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ migrate: ## Apply Hasura migrations
 		echo "Visit: https://hasura.io/docs/latest/hasura-cli/install-hasura-cli/"; \
 		exit 1; \
 	fi
-	@cd hasura && hasura migrate apply --admin-secret $(HASURA_GRAPHQL_ADMIN_SECRET)
+	@cd hasura && hasura migrate apply --database-name default --admin-secret $(HASURA_GRAPHQL_ADMIN_SECRET)
 	@cd hasura && hasura metadata apply --admin-secret $(HASURA_GRAPHQL_ADMIN_SECRET)
 
 migrate-status: ## Check Hasura migration status


### PR DESCRIPTION
Part 1 of 4 in the Shared Classes stack (backend). Base is `main`; the rest of the stack builds on this one in order: migrate-fix -> schema -> api -> invite-validation.

Fixes `make migrate` for the pinned Hasura CLI: without `--database-name`, it fails outright with "--database-name flag is required" before ever reaching pending migrations. Unrelated to shared classes itself, but the schema PR after this one needs it to apply locally.
