### PR TITLE
Add shared classes group tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ migrate: ## Apply Hasura migrations
 		echo "Visit: https://hasura.io/docs/latest/hasura-cli/install-hasura-cli/"; \
 		exit 1; \
 	fi
-	@cd hasura && hasura migrate apply --admin-secret $(HASURA_GRAPHQL_ADMIN_SECRET)
+	@cd hasura && hasura migrate apply --database-name default --admin-secret $(HASURA_GRAPHQL_ADMIN_SECRET)
 	@cd hasura && hasura metadata apply --admin-secret $(HASURA_GRAPHQL_ADMIN_SECRET)
 
 migrate-status: ## Check Hasura migration status

--- a/hasura/migrations/default/1787415796366_shared_classes/down.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/down.sql
@@ -1,4 +1,6 @@
 DROP TRIGGER IF EXISTS notify_shared_group_invite ON shared_group_invite;
 DROP TABLE IF EXISTS shared_group_invite;
 DROP TABLE IF EXISTS shared_group_member;
+DROP TRIGGER IF EXISTS enforce_shared_group_owner_limit ON shared_group;
+DROP FUNCTION IF EXISTS enforce_shared_group_owner_limit();
 DROP TABLE IF EXISTS shared_group;

--- a/hasura/migrations/default/1787415796366_shared_classes/down.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS shared_group_block;
+DROP TABLE IF EXISTS shared_group_invite;
+DROP TABLE IF EXISTS shared_group_member;
+DROP TABLE IF EXISTS shared_group;

--- a/hasura/migrations/default/1787415796366_shared_classes/down.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/down.sql
@@ -1,4 +1,2 @@
-DROP TABLE IF EXISTS shared_group_block;
-DROP TABLE IF EXISTS shared_group_invite;
 DROP TABLE IF EXISTS shared_group_member;
 DROP TABLE IF EXISTS shared_group;

--- a/hasura/migrations/default/1787415796366_shared_classes/down.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/down.sql
@@ -1,5 +1,7 @@
 DROP TRIGGER IF EXISTS notify_shared_group_invite ON shared_group_invite;
 DROP TABLE IF EXISTS shared_group_invite;
+DROP TRIGGER IF EXISTS enforce_shared_group_member_invite_limit ON shared_group_member;
+DROP FUNCTION IF EXISTS enforce_shared_group_member_invite_limit();
 DROP TABLE IF EXISTS shared_group_member;
 DROP TRIGGER IF EXISTS enforce_shared_group_owner_limit ON shared_group;
 DROP FUNCTION IF EXISTS enforce_shared_group_owner_limit();

--- a/hasura/migrations/default/1787415796366_shared_classes/down.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/down.sql
@@ -1,2 +1,4 @@
+DROP TRIGGER IF EXISTS notify_shared_group_invite ON shared_group_invite;
+DROP TABLE IF EXISTS shared_group_invite;
 DROP TABLE IF EXISTS shared_group_member;
 DROP TABLE IF EXISTS shared_group;

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -17,23 +17,17 @@ CREATE INDEX shared_group_created_by_idx ON shared_group(created_by);
 
 CREATE FUNCTION enforce_shared_group_owner_limit()
 RETURNS TRIGGER AS $$
-DECLARE
-  owned_group_count INT;
 BEGIN
-  IF TG_OP = 'UPDATE' AND NEW.created_by = OLD.created_by THEN
-    RETURN NEW;
-  END IF;
+  -- Serialize concurrent group creation for this owner.
+  PERFORM 1 FROM "user"
+  WHERE id = NEW.created_by
+  FOR NO KEY UPDATE;
 
-  -- Serialize ownership checks for this user so concurrent inserts cannot
-  -- both observe fewer than five groups and exceed the limit.
-  PERFORM 1 FROM "user" WHERE id = NEW.created_by FOR UPDATE;
-
-  SELECT COUNT(*)
-  INTO owned_group_count
-  FROM shared_group
-  WHERE created_by = NEW.created_by;
-
-  IF owned_group_count >= 5 THEN
+  IF (
+    SELECT COUNT(*)
+    FROM shared_group
+    WHERE created_by = NEW.created_by
+  ) > 5 THEN
     RAISE EXCEPTION 'A user cannot own more than 5 shared groups'
       USING ERRCODE = 'check_violation';
   END IF;
@@ -43,7 +37,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER enforce_shared_group_owner_limit
-BEFORE INSERT OR UPDATE OF created_by ON shared_group
+AFTER INSERT OR UPDATE OF created_by ON shared_group
 FOR EACH ROW EXECUTE FUNCTION enforce_shared_group_owner_limit();
 
 -- One row per person in a group. A 'pending' row is how an invite is
@@ -68,39 +62,17 @@ CREATE INDEX shared_group_member_user_id_idx ON shared_group_member(user_id);
 
 CREATE FUNCTION enforce_shared_group_member_invite_limit()
 RETURNS TRIGGER AS $$
-DECLARE
-  pending_invite_count INT;
 BEGIN
-  IF NEW.status <> 'pending' THEN
-    RETURN NEW;
-  END IF;
+  -- Serialize concurrent invitations for this recipient.
+  PERFORM 1 FROM "user"
+  WHERE id = NEW.user_id
+  FOR NO KEY UPDATE;
 
-  IF TG_OP = 'UPDATE'
-    AND OLD.status = 'pending'
-    AND NEW.user_id = OLD.user_id THEN
-    RETURN NEW;
-  END IF;
-
-  -- Serialize invite checks for this recipient so concurrent inserts cannot
-  -- both observe fewer than ten pending invitations and exceed the limit.
-  PERFORM 1 FROM "user" WHERE id = NEW.user_id FOR UPDATE;
-
-  -- Invite creation uses ON CONFLICT DO NOTHING. Let an existing membership
-  -- reach that conflict handler even when the recipient is already at the cap.
-  IF TG_OP = 'INSERT' AND EXISTS (
-    SELECT 1
+  IF (
+    SELECT COUNT(*)
     FROM shared_group_member
-    WHERE group_id = NEW.group_id AND user_id = NEW.user_id
-  ) THEN
-    RETURN NEW;
-  END IF;
-
-  SELECT COUNT(*)
-  INTO pending_invite_count
-  FROM shared_group_member
-  WHERE user_id = NEW.user_id AND status = 'pending';
-
-  IF pending_invite_count >= 10 THEN
+    WHERE user_id = NEW.user_id AND status = 'pending'
+  ) > 10 THEN
     RAISE EXCEPTION 'A user cannot have more than 10 pending shared group invites'
       USING ERRCODE = 'check_violation';
   END IF;
@@ -110,8 +82,10 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER enforce_shared_group_member_invite_limit
-BEFORE INSERT OR UPDATE OF user_id, status ON shared_group_member
-FOR EACH ROW EXECUTE FUNCTION enforce_shared_group_member_invite_limit();
+AFTER INSERT OR UPDATE OF user_id, status ON shared_group_member
+FOR EACH ROW
+WHEN (NEW.status = 'pending')
+EXECUTE FUNCTION enforce_shared_group_member_invite_limit();
 
 -- A pending shared_group_member row can only represent an invite to someone
 -- who already has an account, since it is keyed by user id. This table covers

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -1,0 +1,72 @@
+-- Shared Classes: small groups where members compare the schedules Flow
+-- already stores and see which sections they share. No schedule data is
+-- duplicated here; these tables only record group membership and invites.
+
+CREATE TABLE shared_group (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+    CONSTRAINT shared_group_name_length CHECK (LENGTH(name) BETWEEN 1 AND 80),
+  created_by INT NOT NULL
+    REFERENCES "user"(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One row per person in a group. status is 'pending' after an invite is
+-- accepted into an account but before the person opts in, and 'member' once
+-- they are sharing. Only 'member' rows contribute to shared-class results.
+CREATE TABLE shared_group_member (
+  group_id INT NOT NULL
+    REFERENCES shared_group(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  user_id INT NOT NULL
+    REFERENCES "user"(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CONSTRAINT shared_group_member_status CHECK (status IN ('pending', 'member')),
+  joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT shared_group_member_pkey PRIMARY KEY (group_id, user_id)
+);
+
+CREATE INDEX shared_group_member_user_id_idx ON shared_group_member(user_id);
+
+-- An invite is keyed by the email it was sent to, so an invite can exist
+-- before that email has a Flow account. invited_by is the member who sent it.
+CREATE TABLE shared_group_invite (
+  id SERIAL PRIMARY KEY,
+  group_id INT NOT NULL
+    REFERENCES shared_group(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  invited_email TEXT NOT NULL,
+  invited_by INT NOT NULL
+    REFERENCES "user"(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  status TEXT NOT NULL DEFAULT 'invited'
+    CONSTRAINT shared_group_invite_status
+      CHECK (status IN ('invited', 'accepted', 'declined')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT shared_group_invite_unique UNIQUE (group_id, invited_email)
+);
+
+CREATE INDEX shared_group_invite_group_id_idx ON shared_group_invite(group_id);
+
+-- Block list: user_id has blocked blocked_user_id from inviting them again.
+-- Future invites from a blocked person are dropped silently.
+CREATE TABLE shared_group_block (
+  user_id INT NOT NULL
+    REFERENCES "user"(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  blocked_user_id INT NOT NULL
+    REFERENCES "user"(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT shared_group_block_pkey PRIMARY KEY (user_id, blocked_user_id),
+  CONSTRAINT shared_group_block_not_self CHECK (user_id <> blocked_user_id)
+);

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -15,6 +15,9 @@ CREATE TABLE shared_group (
 
 CREATE INDEX shared_group_created_by_idx ON shared_group(created_by);
 
+-- PostgreSQL cannot express cross-row count limits with a CHECK constraint, so
+-- the ownership and pending-invite limits use triggers. See:
+-- https://stackoverflow.com/questions/1743439/how-to-write-a-constraint-concerning-a-max-number-of-rows-in-postgresql
 CREATE FUNCTION enforce_shared_group_owner_limit()
 RETURNS TRIGGER AS $$
 BEGIN

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -27,8 +27,8 @@ BEGIN
     SELECT COUNT(*)
     FROM shared_group
     WHERE created_by = NEW.created_by
-  ) > 5 THEN
-    RAISE EXCEPTION 'A user cannot own more than 5 shared groups'
+  ) > 10 THEN
+    RAISE EXCEPTION 'A user cannot own more than 10 shared groups'
       USING ERRCODE = 'check_violation';
   END IF;
 
@@ -72,8 +72,8 @@ BEGIN
     SELECT COUNT(*)
     FROM shared_group_member
     WHERE user_id = NEW.user_id AND status = 'pending'
-  ) > 10 THEN
-    RAISE EXCEPTION 'A user cannot have more than 10 pending shared group invites'
+  ) > 20 THEN
+    RAISE EXCEPTION 'A user cannot have more than 20 pending shared group invites'
       USING ERRCODE = 'check_violation';
   END IF;
 

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -13,6 +13,39 @@ CREATE TABLE shared_group (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+CREATE INDEX shared_group_created_by_idx ON shared_group(created_by);
+
+CREATE FUNCTION enforce_shared_group_owner_limit()
+RETURNS TRIGGER AS $$
+DECLARE
+  owned_group_count INT;
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.created_by = OLD.created_by THEN
+    RETURN NEW;
+  END IF;
+
+  -- Serialize ownership checks for this user so concurrent inserts cannot
+  -- both observe fewer than five groups and exceed the limit.
+  PERFORM 1 FROM "user" WHERE id = NEW.created_by FOR UPDATE;
+
+  SELECT COUNT(*)
+  INTO owned_group_count
+  FROM shared_group
+  WHERE created_by = NEW.created_by;
+
+  IF owned_group_count >= 5 THEN
+    RAISE EXCEPTION 'A user cannot own more than 5 shared groups'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER enforce_shared_group_owner_limit
+BEFORE INSERT OR UPDATE OF created_by ON shared_group
+FOR EACH ROW EXECUTE FUNCTION enforce_shared_group_owner_limit();
+
 -- One row per person in a group. A 'pending' row is how an invite is
 -- represented: it is created on invite, flips to 'member' on accept, and is
 -- deleted on decline. Only 'member' rows contribute to shared-class results.

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -32,3 +32,44 @@ CREATE TABLE shared_group_member (
 );
 
 CREATE INDEX shared_group_member_user_id_idx ON shared_group_member(user_id);
+
+-- A pending shared_group_member row can only represent an invite to someone
+-- who already has an account, since it is keyed by user id. This table covers
+-- the other case: an invite addressed to an email with no account behind it.
+-- The row is deleted once it is converted into a shared_group_member on
+-- sign-up, or on decline, the same way a pending member row is.
+CREATE TABLE shared_group_invite (
+  id SERIAL PRIMARY KEY,
+  group_id INT NOT NULL
+    REFERENCES shared_group(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  invited_email TEXT NOT NULL
+    CONSTRAINT shared_group_invite_email_length CHECK (LENGTH(invited_email) <= 256)
+    CONSTRAINT shared_group_invite_email_format
+      CHECK (invited_email ~* '^[A-Z0-9._%+*-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$'),
+  invited_by INT NOT NULL
+    REFERENCES "user"(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  -- The token in the emailed link. It is what lets the recipient act on the
+  -- invite: they have no session to be identified by until they sign up.
+  secret_key TEXT NOT NULL
+    CONSTRAINT shared_group_invite_secret_key_unique UNIQUE
+    DEFAULT REPLACE(GEN_RANDOM_UUID()::TEXT, '-', ''),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- The mail service scans for a NULL here and stamps it once the invite has
+  -- been sent. Without it every notification would re-mail every outstanding
+  -- invite, since a scan reads all unsent rows rather than the one that fired.
+  mailed_at TIMESTAMPTZ DEFAULT NULL,
+  CONSTRAINT shared_group_invite_unique UNIQUE (group_id, invited_email)
+);
+
+CREATE INDEX shared_group_invite_group_id_idx ON shared_group_invite(group_id);
+
+-- The queue tables the mail service reads all name a "user" row it takes the
+-- recipient address off, which is what limits mail to people who already have
+-- an account. An invite carries its own address, so it is notified on directly
+-- and needs no queue table standing in front of it.
+CREATE TRIGGER notify_shared_group_invite AFTER INSERT ON shared_group_invite
+FOR EACH STATEMENT EXECUTE PROCEDURE sendmail_notify('shared_group_invite');

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -1,6 +1,6 @@
 -- Shared Classes: small groups where members compare the schedules Flow
 -- already stores and see which sections they share. No schedule data is
--- duplicated here; these tables only record group membership and invites.
+-- duplicated here; these tables only record group membership.
 
 CREATE TABLE shared_group (
   id SERIAL PRIMARY KEY,
@@ -13,9 +13,9 @@ CREATE TABLE shared_group (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- One row per person in a group. status is 'pending' after an invite is
--- accepted into an account but before the person opts in, and 'member' once
--- they are sharing. Only 'member' rows contribute to shared-class results.
+-- One row per person in a group. A 'pending' row is how an invite is
+-- represented: it is created on invite, flips to 'member' on accept, and is
+-- deleted on decline. Only 'member' rows contribute to shared-class results.
 CREATE TABLE shared_group_member (
   group_id INT NOT NULL
     REFERENCES shared_group(id)
@@ -32,41 +32,3 @@ CREATE TABLE shared_group_member (
 );
 
 CREATE INDEX shared_group_member_user_id_idx ON shared_group_member(user_id);
-
--- An invite is keyed by the email it was sent to, so an invite can exist
--- before that email has a Flow account. invited_by is the member who sent it.
-CREATE TABLE shared_group_invite (
-  id SERIAL PRIMARY KEY,
-  group_id INT NOT NULL
-    REFERENCES shared_group(id)
-    ON DELETE CASCADE
-    ON UPDATE CASCADE,
-  invited_email TEXT NOT NULL,
-  invited_by INT NOT NULL
-    REFERENCES "user"(id)
-    ON DELETE CASCADE
-    ON UPDATE CASCADE,
-  status TEXT NOT NULL DEFAULT 'invited'
-    CONSTRAINT shared_group_invite_status
-      CHECK (status IN ('invited', 'accepted', 'declined')),
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  CONSTRAINT shared_group_invite_unique UNIQUE (group_id, invited_email)
-);
-
-CREATE INDEX shared_group_invite_group_id_idx ON shared_group_invite(group_id);
-
--- Block list: user_id has blocked blocked_user_id from inviting them again.
--- Future invites from a blocked person are dropped silently.
-CREATE TABLE shared_group_block (
-  user_id INT NOT NULL
-    REFERENCES "user"(id)
-    ON DELETE CASCADE
-    ON UPDATE CASCADE,
-  blocked_user_id INT NOT NULL
-    REFERENCES "user"(id)
-    ON DELETE CASCADE
-    ON UPDATE CASCADE,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  CONSTRAINT shared_group_block_pkey PRIMARY KEY (user_id, blocked_user_id),
-  CONSTRAINT shared_group_block_not_self CHECK (user_id <> blocked_user_id)
-);

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -27,7 +27,7 @@ CREATE TABLE shared_group_member (
     ON UPDATE CASCADE,
   status TEXT NOT NULL DEFAULT 'pending'
     CONSTRAINT shared_group_member_status CHECK (status IN ('pending', 'member')),
-  joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   CONSTRAINT shared_group_member_pkey PRIMARY KEY (group_id, user_id)
 );
 

--- a/hasura/migrations/default/1787415796366_shared_classes/up.sql
+++ b/hasura/migrations/default/1787415796366_shared_classes/up.sql
@@ -66,6 +66,53 @@ CREATE TABLE shared_group_member (
 
 CREATE INDEX shared_group_member_user_id_idx ON shared_group_member(user_id);
 
+CREATE FUNCTION enforce_shared_group_member_invite_limit()
+RETURNS TRIGGER AS $$
+DECLARE
+  pending_invite_count INT;
+BEGIN
+  IF NEW.status <> 'pending' THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+    AND OLD.status = 'pending'
+    AND NEW.user_id = OLD.user_id THEN
+    RETURN NEW;
+  END IF;
+
+  -- Serialize invite checks for this recipient so concurrent inserts cannot
+  -- both observe fewer than ten pending invitations and exceed the limit.
+  PERFORM 1 FROM "user" WHERE id = NEW.user_id FOR UPDATE;
+
+  -- Invite creation uses ON CONFLICT DO NOTHING. Let an existing membership
+  -- reach that conflict handler even when the recipient is already at the cap.
+  IF TG_OP = 'INSERT' AND EXISTS (
+    SELECT 1
+    FROM shared_group_member
+    WHERE group_id = NEW.group_id AND user_id = NEW.user_id
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO pending_invite_count
+  FROM shared_group_member
+  WHERE user_id = NEW.user_id AND status = 'pending';
+
+  IF pending_invite_count >= 10 THEN
+    RAISE EXCEPTION 'A user cannot have more than 10 pending shared group invites'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER enforce_shared_group_member_invite_limit
+BEFORE INSERT OR UPDATE OF user_id, status ON shared_group_member
+FOR EACH ROW EXECUTE FUNCTION enforce_shared_group_member_invite_limit();
+
 -- A pending shared_group_member row can only represent an invite to someone
 -- who already has an account, since it is keyed by user id. This table covers
 -- the other case: an invite addressed to an email with no account behind it.


### PR DESCRIPTION
Part 2 of 4 in the Shared Classes stack (backend). Base is `shared-classes-migrate-fix`; review this as the diff against that branch, not `main`.

Migration adding `shared_group`, `shared_group_member`, `shared_group_invite` and `shared_group_block`, backing the group API that lands in the next PR.
