### PR TITLE
Only invite existing accounts to shared groups

### DIFF
--- a/flow/api/group/group.go
+++ b/flow/api/group/group.go
@@ -7,6 +7,7 @@ package group
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -16,6 +17,7 @@ import (
 	"flow/common/db"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 )
 
 // groupId reads and validates the {id} path parameter.
@@ -359,8 +361,11 @@ func Invite(tx *db.Tx, r *http.Request) (interface{}, error) {
 	// built here.
 	var targetId int
 	err = tx.QueryRow(`SELECT id FROM "user" WHERE LOWER(email) = $1`, email).Scan(&targetId)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return map[string]interface{}{"status": "not_found"}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("looking up invited account: %w", err)
 	}
 
 	// A pending shared_group_member row is the invite: the person accepts by

--- a/flow/api/group/group.go
+++ b/flow/api/group/group.go
@@ -319,9 +319,9 @@ func attachMeetings(tx *db.Tx, sectionIds []int, byId map[int]*sharedClass) erro
 	return rows.Err()
 }
 
-// Invite resolves an email to a Flow account server-side and, when possible,
-// adds them as a pending member. The response is always "sent" so the endpoint
-// cannot be used to probe which emails have accounts.
+// Invite resolves an email to a Flow account and adds that person as a pending
+// member. It returns "sent" on success and "not_found" when no account uses
+// that email, so the inviter learns whether the invite reached anyone.
 func Invite(tx *db.Tx, r *http.Request) (interface{}, error) {
 	userId, err := serde.UserIdFromRequest(r)
 	if err != nil {
@@ -352,13 +352,15 @@ func Invite(tx *db.Tx, r *http.Request) (interface{}, error) {
 
 	sent := map[string]interface{}{"status": "sent"}
 
-	// Resolve the email to an account. Nothing about the outcome is returned.
+	// Resolve the email to an account first. Invites only go to people who
+	// already have a Flow account, so if there is no match we report it back
+	// instead of creating a pending member for no one. Inviting an email with
+	// no account (and emailing them to sign up) is possible future work, not
+	// built here.
 	var targetId int
 	err = tx.QueryRow(`SELECT id FROM "user" WHERE LOWER(email) = $1`, email).Scan(&targetId)
 	if err != nil {
-		// No account (or lookup miss): nothing to add yet. Email delivery to
-		// non-users is not wired up; that is possible future work.
-		return sent, nil
+		return map[string]interface{}{"status": "not_found"}, nil
 	}
 
 	// A pending shared_group_member row is the invite: the person accepts by


### PR DESCRIPTION
Part 4 of 4 in the Shared Classes stack (backend). Base is `shared-classes-api`; review this as the diff against that branch, not `main`.

Resolves the invited email to a Flow account before doing anything. If no account uses that email, returns a `not_found` status instead of recording a dangling invite, so the inviter learns the invite did not reach anyone. Blocked inviters still get a "sent" response so they cannot tell they were blocked.
