### PR TITLE
feat(admin): read-only user impersonation console

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,47 @@ This will rebuild your importer using your local code, and then run the import j
 
 Hasura supports live reloading as well, due to its configuration.
 
+## Admin console
+
+Staff accounts can search users and open a **read-only** session as one of them,
+to see the site as that person sees it. The console lives at `/admin` in the
+frontend and is served by `/api/admin/*`.
+
+### Granting admin access
+
+Admin is a column on `"user"`; there is no self-service path to it:
+
+```sh
+$ docker exec postgres psql -U postgres -d $POSTGRES_DB \
+    -c "UPDATE \"user\" SET is_admin = TRUE WHERE email = 'you@uwflow.com';"
+```
+
+### How impersonation is contained
+
+- **Read-only.** The session's JWT carries the `impersonated_user` Hasura role,
+  which has select permissions only, so Hasura exposes no mutation root to it.
+  `impersonated_user` is also the *only* role in `x-hasura-allowed-roles` on
+  that token — clients may choose any allowed role via `x-hasura-role`, so
+  listing `user` there would hand the session write access on request.
+- **API routes too.** Handlers that write to Postgres directly never pass
+  through Hasura, so the write endpoints (`/parse/*`, `DELETE /user`) are
+  wrapped in `middleware.RejectImpersonation`. Any new route that writes on
+  behalf of the caller belongs in that group in `api/main.go`.
+- **Short-lived.** Impersonation tokens expire after an hour and
+  `/auth/refresh` refuses to renew them, so the cap cannot be extended by
+  staying logged in.
+- **Audited.** Every session inserts a row into `admin_impersonation_log`
+  before the token is minted, so a session cannot exist unrecorded. The console
+  shows the log to all admins, not just its author.
+- **Not chainable, not reflexive.** An impersonation token cannot open the
+  console, and admins may impersonate neither themselves nor each other.
+
+One caveat worth knowing: JWTs are stateless, so "Exit" closes out the audit
+record and returns the admin's own token, but the impersonation token it
+replaces stays cryptographically valid until it expires. The one-hour lifetime
+is what bounds that window — genuine revocation would mean moving Hasura from
+JWT auth to webhook auth.
+
 ## Interacting with the backend
 
 When `docker-compose` is active, services may be accessed

--- a/flow/api/admin/admin.go
+++ b/flow/api/admin/admin.go
@@ -1,0 +1,414 @@
+// Package admin implements the staff-facing console: looking users up and
+// opening a read-only impersonation session against one of them.
+//
+// Two rules hold everywhere in this package:
+//
+//  1. Every handler resolves the caller through requireAdmin, which refuses
+//     both non-admins and anyone already inside an impersonation session. An
+//     impersonation token can therefore never be used to start another one, so
+//     sessions cannot be chained to launder who did what.
+//  2. Impersonation is recorded before the token is issued. If the audit
+//     insert fails the transaction rolls back and no token is minted, so a
+//     session cannot exist without a row describing it.
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"flow/api/serde"
+	"flow/common/db"
+)
+
+const isAdminQuery = `SELECT is_admin FROM "user" WHERE id = $1`
+
+// requireAdmin authenticates the caller and asserts they may use the console.
+func requireAdmin(tx *db.Tx, r *http.Request) (int, error) {
+	claims, err := serde.ClaimsFromRequest(r)
+	if err != nil {
+		return 0, serde.WithStatus(http.StatusUnauthorized, fmt.Errorf("extracting claims: %w", err))
+	}
+
+	// An impersonation session acts as the target, who is by construction not
+	// an admin — but refuse explicitly rather than relying on that, so the rule
+	// survives any future change to who can be impersonated.
+	if claims.Impersonating() {
+		return 0, serde.WithStatus(http.StatusForbidden, serde.WithEnum(
+			serde.ImpersonationForbidden,
+			fmt.Errorf("cannot use the admin console while impersonating"),
+		))
+	}
+
+	userId, err := claims.UserId()
+	if err != nil {
+		return 0, serde.WithStatus(http.StatusUnauthorized, err)
+	}
+
+	var isAdmin bool
+	if err := tx.QueryRow(isAdminQuery, userId).Scan(&isAdmin); err != nil {
+		// A token for a deleted user lands here: no row, so no admin.
+		return 0, serde.WithStatus(http.StatusForbidden, serde.WithEnum(
+			serde.NotAdmin, fmt.Errorf("loading admin flag for user %d: %w", userId, err),
+		))
+	}
+	if !isAdmin {
+		return 0, serde.WithStatus(http.StatusForbidden, serde.WithEnum(
+			serde.NotAdmin, fmt.Errorf("user %d is not an admin", userId),
+		))
+	}
+
+	return userId, nil
+}
+
+/* GET /admin/me */
+
+type whoAmIResponse struct {
+	UserId  int  `json:"user_id"`
+	IsAdmin bool `json:"is_admin"`
+}
+
+// HandleWhoAmI lets the frontend gate the console's entry points. It is the
+// only admin route that answers 200 for a non-admin, because "no" is a normal
+// answer here rather than a rejection.
+func HandleWhoAmI(tx *db.Tx, r *http.Request) (interface{}, error) {
+	claims, err := serde.ClaimsFromRequest(r)
+	if err != nil {
+		return nil, serde.WithStatus(http.StatusUnauthorized, fmt.Errorf("extracting claims: %w", err))
+	}
+
+	userId, err := claims.UserId()
+	if err != nil {
+		return nil, serde.WithStatus(http.StatusUnauthorized, err)
+	}
+
+	// Never report an impersonated session as an admin one, whatever the
+	// target's flag says.
+	if claims.Impersonating() {
+		return &whoAmIResponse{UserId: userId, IsAdmin: false}, nil
+	}
+
+	var isAdmin bool
+	if err := tx.QueryRow(isAdminQuery, userId).Scan(&isAdmin); err != nil {
+		return nil, fmt.Errorf("loading admin flag: %w", err)
+	}
+
+	return &whoAmIResponse{UserId: userId, IsAdmin: isAdmin}, nil
+}
+
+/* GET /admin/users */
+
+// Counts come from correlated subqueries rather than joins with GROUP BY:
+// the result set is capped at searchLimit rows, so this stays cheap and keeps
+// users with no reviews or no schedule in the results.
+const searchUsersQuery = `
+SELECT
+  u.id,
+  u.first_name,
+  u.last_name,
+  u.email,
+  u.program,
+  u.picture_url,
+  u.join_source,
+  u.join_date,
+  u.is_admin,
+  (SELECT COUNT(*) FROM review r WHERE r.user_id = u.id),
+  (SELECT COUNT(*) FROM user_schedule s WHERE s.user_id = u.id)
+FROM "user" u
+WHERE
+  $1 = ''
+  OR u.email ILIKE '%' || $1 || '%'
+  OR u.full_name ILIKE '%' || $1 || '%'
+  OR CAST(u.id AS TEXT) = $1
+ORDER BY
+  -- Exact id match first, so pasting an id from a bug report lands on it even
+  -- when the digits also appear inside somebody's email address.
+  (CAST(u.id AS TEXT) = $1) DESC,
+  u.join_date DESC
+LIMIT $2
+`
+
+const searchLimit = 50
+
+type adminUser struct {
+	Id           int     `json:"id"`
+	FirstName    string  `json:"first_name"`
+	LastName     string  `json:"last_name"`
+	Email        *string `json:"email"`
+	Program      *string `json:"program"`
+	PictureUrl   *string `json:"picture_url"`
+	JoinSource   string  `json:"join_source"`
+	JoinDate     string  `json:"join_date"`
+	IsAdmin      bool    `json:"is_admin"`
+	ReviewCount  int     `json:"review_count"`
+	ScheduleSize int     `json:"schedule_size"`
+}
+
+type searchUsersResponse struct {
+	Users []adminUser `json:"users"`
+}
+
+func HandleSearchUsers(tx *db.Tx, r *http.Request) (interface{}, error) {
+	if _, err := requireAdmin(tx, r); err != nil {
+		return nil, err
+	}
+
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+
+	rows, err := tx.Query(searchUsersQuery, query, searchLimit)
+	if err != nil {
+		return nil, fmt.Errorf("searching users: %w", err)
+	}
+	defer rows.Close()
+
+	// Not `var users []adminUser`: a nil slice marshals to `null`, and the
+	// frontend would have to defend against it on every empty search.
+	users := []adminUser{}
+	for rows.Next() {
+		var u adminUser
+		var joinDate time.Time
+		err := rows.Scan(
+			&u.Id, &u.FirstName, &u.LastName, &u.Email, &u.Program, &u.PictureUrl,
+			&u.JoinSource, &joinDate, &u.IsAdmin, &u.ReviewCount, &u.ScheduleSize,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scanning user: %w", err)
+		}
+		u.JoinDate = joinDate.Format(time.RFC3339)
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating users: %w", err)
+	}
+
+	return &searchUsersResponse{Users: users}, nil
+}
+
+/* POST /admin/impersonate */
+
+const targetQuery = `SELECT first_name, last_name, email, is_admin FROM "user" WHERE id = $1`
+
+const logImpersonationQuery = `
+INSERT INTO admin_impersonation_log(admin_id, target_user_id, reason)
+VALUES ($1, $2, $3) RETURNING id
+`
+
+type impersonateBody struct {
+	UserId int    `json:"user_id"`
+	Reason string `json:"reason"`
+}
+
+type impersonateResponse struct {
+	Token     string  `json:"token"`
+	UserId    int     `json:"user_id"`
+	FullName  string  `json:"full_name"`
+	Email     *string `json:"email"`
+	SessionId int     `json:"session_id"`
+	ExpiresIn int     `json:"expires_in"`
+}
+
+func HandleImpersonate(tx *db.Tx, r *http.Request) (interface{}, error) {
+	adminId, err := requireAdmin(tx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	var body impersonateBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return nil, serde.WithStatus(http.StatusBadRequest, fmt.Errorf("decoding body: %w", err))
+	}
+
+	if body.UserId == adminId {
+		return nil, serde.WithStatus(http.StatusBadRequest, serde.WithEnum(
+			serde.InvalidImpersonationTarget, fmt.Errorf("cannot impersonate yourself"),
+		))
+	}
+
+	var firstName, lastName string
+	var email *string
+	var targetIsAdmin bool
+	err = tx.QueryRow(targetQuery, body.UserId).Scan(&firstName, &lastName, &email, &targetIsAdmin)
+	if err != nil {
+		return nil, serde.WithStatus(http.StatusNotFound, serde.WithEnum(
+			serde.InvalidImpersonationTarget,
+			fmt.Errorf("loading impersonation target %d: %w", body.UserId, err),
+		))
+	}
+
+	// Admins are off limits to each other. Impersonating one would inherit
+	// their console access and let an admin act with another's identity, which
+	// is exactly what the audit log is supposed to prevent.
+	if targetIsAdmin {
+		return nil, serde.WithStatus(http.StatusForbidden, serde.WithEnum(
+			serde.InvalidImpersonationTarget, fmt.Errorf("cannot impersonate another admin"),
+		))
+	}
+
+	reason := strings.TrimSpace(body.Reason)
+	if len(reason) > 500 {
+		reason = reason[:500]
+	}
+	var reasonArg *string
+	if reason != "" {
+		reasonArg = &reason
+	}
+
+	// Recorded before the token exists: see the package comment.
+	var sessionId int
+	err = tx.QueryRow(logImpersonationQuery, adminId, body.UserId, reasonArg).Scan(&sessionId)
+	if err != nil {
+		return nil, fmt.Errorf("recording impersonation: %w", err)
+	}
+
+	token, err := serde.NewImpersonationJwt(body.UserId, adminId)
+	if err != nil {
+		return nil, fmt.Errorf("signing impersonation jwt: %w", err)
+	}
+
+	return &impersonateResponse{
+		Token:     token,
+		UserId:    body.UserId,
+		FullName:  firstName + " " + lastName,
+		Email:     email,
+		SessionId: sessionId,
+		ExpiresIn: int(serde.ImpersonationExpirationPeriod.Seconds()),
+	}, nil
+}
+
+/* POST /admin/impersonate/stop */
+
+const endImpersonationQuery = `
+UPDATE admin_impersonation_log
+SET ended_at = NOW()
+WHERE id = $1 AND admin_id = $2 AND ended_at IS NULL
+`
+
+type stopImpersonatingBody struct {
+	SessionId int `json:"session_id"`
+}
+
+type stopImpersonatingResponse struct {
+	Token  string `json:"token"`
+	UserId int    `json:"user_id"`
+}
+
+// HandleStopImpersonating exchanges an impersonation token for a fresh token
+// for the admin behind it. The admin's identity is taken from the signed `imp`
+// claim, so exiting never depends on the client having held on to the original
+// token — closing the tab mid-session does not strand the account.
+func HandleStopImpersonating(tx *db.Tx, r *http.Request) (interface{}, error) {
+	claims, err := serde.ClaimsFromRequest(r)
+	if err != nil {
+		return nil, serde.WithStatus(http.StatusUnauthorized, fmt.Errorf("extracting claims: %w", err))
+	}
+
+	if !claims.Impersonating() {
+		return nil, serde.WithStatus(http.StatusBadRequest, fmt.Errorf("not an impersonation session"))
+	}
+
+	adminId := claims.Impersonator
+
+	// Re-check the flag: an admin demoted mid-session should not be handed a
+	// working token for their old account.
+	var isAdmin bool
+	if err := tx.QueryRow(isAdminQuery, adminId).Scan(&isAdmin); err != nil || !isAdmin {
+		return nil, serde.WithStatus(http.StatusForbidden, serde.WithEnum(
+			serde.NotAdmin, fmt.Errorf("impersonator %d is no longer an admin", adminId),
+		))
+	}
+
+	var body stopImpersonatingBody
+	// A missing or malformed body is not fatal — closing out the audit row is
+	// best-effort, and refusing to return the admin's token over it would
+	// leave them stuck as the user.
+	json.NewDecoder(r.Body).Decode(&body)
+	if body.SessionId != 0 {
+		if _, err := tx.Exec(endImpersonationQuery, body.SessionId, adminId); err != nil {
+			return nil, fmt.Errorf("closing impersonation record: %w", err)
+		}
+	}
+
+	token, err := serde.NewSignedJwt(adminId)
+	if err != nil {
+		return nil, fmt.Errorf("signing jwt: %w", err)
+	}
+
+	return &stopImpersonatingResponse{Token: token, UserId: adminId}, nil
+}
+
+/* GET /admin/impersonation-log */
+
+const impersonationLogQuery = `
+SELECT
+  l.id,
+  l.admin_id,
+  a.full_name,
+  l.target_user_id,
+  t.full_name,
+  l.reason,
+  l.started_at,
+  l.ended_at
+FROM admin_impersonation_log l
+  JOIN "user" a ON a.id = l.admin_id
+  JOIN "user" t ON t.id = l.target_user_id
+ORDER BY l.started_at DESC
+LIMIT $1
+`
+
+const logLimit = 100
+
+type impersonationLogEntry struct {
+	Id             int     `json:"id"`
+	AdminId        int     `json:"admin_id"`
+	AdminName      string  `json:"admin_name"`
+	TargetUserId   int     `json:"target_user_id"`
+	TargetUserName string  `json:"target_user_name"`
+	Reason         *string `json:"reason"`
+	StartedAt      string  `json:"started_at"`
+	EndedAt        *string `json:"ended_at"`
+}
+
+type impersonationLogResponse struct {
+	Entries []impersonationLogEntry `json:"entries"`
+}
+
+// HandleImpersonationLog returns the audit trail for every admin, not just the
+// caller: mutual visibility is the point of keeping it.
+func HandleImpersonationLog(tx *db.Tx, r *http.Request) (interface{}, error) {
+	if _, err := requireAdmin(tx, r); err != nil {
+		return nil, err
+	}
+
+	rows, err := tx.Query(impersonationLogQuery, logLimit)
+	if err != nil {
+		return nil, fmt.Errorf("loading impersonation log: %w", err)
+	}
+	defer rows.Close()
+
+	entries := []impersonationLogEntry{}
+	for rows.Next() {
+		var e impersonationLogEntry
+		var startedAt time.Time
+		var endedAt *time.Time
+		err := rows.Scan(
+			&e.Id, &e.AdminId, &e.AdminName, &e.TargetUserId, &e.TargetUserName,
+			&e.Reason, &startedAt, &endedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scanning log entry: %w", err)
+		}
+		e.StartedAt = startedAt.Format(time.RFC3339)
+		if endedAt != nil {
+			formatted := endedAt.Format(time.RFC3339)
+			e.EndedAt = &formatted
+		}
+		entries = append(entries, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating log: %w", err)
+	}
+
+	return &impersonationLogResponse{Entries: entries}, nil
+}

--- a/flow/api/auth/refresh.go
+++ b/flow/api/auth/refresh.go
@@ -13,9 +13,31 @@ type refreshResponse struct {
 }
 
 func RefreshToken(tx *db.Tx, r *http.Request) (interface{}, error) {
-	userId, err := serde.UserIdFromRequest(r)
+	claims, err := serde.ClaimsFromRequest(r)
 	if err != nil {
-		return nil, serde.WithStatus(http.StatusUnauthorized, fmt.Errorf("extracting user id: %w", err))
+		return nil, serde.WithStatus(http.StatusUnauthorized, fmt.Errorf("extracting claims: %w", err))
+	}
+
+	userId, err := claims.UserId()
+	if err != nil {
+		return nil, serde.WithStatus(http.StatusUnauthorized, err)
+	}
+
+	// Refreshing an impersonation token must not quietly launder it into an
+	// ordinary one. Minting the usual token here would hand the caller the
+	// write-capable `user` role for an account that is not theirs, and drop the
+	// `imp` claim that ties the session to an admin — turning a bounded,
+	// audited, read-only session into an indistinguishable full login.
+	//
+	// Refuse instead of re-issuing: impersonation is deliberately capped at
+	// ImpersonationExpirationPeriod, and renewing it on a timer would defeat
+	// that cap. The admin can open a fresh session, which writes a new audit
+	// row, as it should.
+	if claims.Impersonating() {
+		return nil, serde.WithStatus(http.StatusForbidden, serde.WithEnum(
+			serde.ImpersonationForbidden,
+			fmt.Errorf("impersonation sessions cannot be refreshed"),
+		))
 	}
 
 	token, err := serde.NewSignedJwt(userId)

--- a/flow/api/main.go
+++ b/flow/api/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	_ "time/tzdata"
 
+	"flow/api/admin"
 	"flow/api/auth"
 	"flow/api/calendar"
 	"flow/api/data"
@@ -75,14 +76,27 @@ func setupRouter(conn *db.Conn) *chi.Mux {
 		serde.WithDbNoResponse(conn, auth.ResetPassword, "password reset completion"),
 	)
 
-	router.Post(
-		"/parse/transcript",
-		serde.WithDbResponse(conn, parse.HandleTranscript, "transcript upload"),
-	)
-	router.Post(
-		"/parse/schedule",
-		serde.WithDbResponse(conn, parse.HandleSchedule, "schedule upload"),
-	)
+	// Routes that write to the caller's account go through the DB directly
+	// rather than through Hasura, so the `impersonated_user` role's select-only
+	// permissions do not cover them. RejectImpersonation is what makes an
+	// impersonation session read-only here too; any future route that writes on
+	// behalf of the caller belongs in this group.
+	router.Group(func(r chi.Router) {
+		r.Use(middleware.RejectImpersonation())
+
+		r.Post(
+			"/parse/transcript",
+			serde.WithDbResponse(conn, parse.HandleTranscript, "transcript upload"),
+		)
+		r.Post(
+			"/parse/schedule",
+			serde.WithDbResponse(conn, parse.HandleSchedule, "schedule upload"),
+		)
+		r.Delete(
+			"/user",
+			serde.WithDbDirect(conn, auth.DeleteAccount, "account deletion"),
+		)
+	})
 
 	router.Get(
 		"/data/search",
@@ -94,9 +108,27 @@ func setupRouter(conn *db.Conn) *chi.Mux {
 		serde.WithDbDirect(conn, calendar.HandleCalendar, "calendar generation"),
 	)
 
-	router.Delete(
-		"/user",
-		serde.WithDbDirect(conn, auth.DeleteAccount, "account deletion"),
+	// Admin console. Each handler asserts the caller is an admin itself, so
+	// these are safe to mount without further gating here.
+	router.Get(
+		"/admin/me",
+		serde.WithDbResponse(conn, admin.HandleWhoAmI, "admin identity check"),
+	)
+	router.Get(
+		"/admin/users",
+		serde.WithDbResponse(conn, admin.HandleSearchUsers, "admin user search"),
+	)
+	router.Get(
+		"/admin/impersonation-log",
+		serde.WithDbResponse(conn, admin.HandleImpersonationLog, "impersonation log"),
+	)
+	router.Post(
+		"/admin/impersonate",
+		serde.WithDbResponse(conn, admin.HandleImpersonate, "impersonation start"),
+	)
+	router.Post(
+		"/admin/impersonate/stop",
+		serde.WithDbResponse(conn, admin.HandleStopImpersonating, "impersonation stop"),
 	)
 
 	return router

--- a/flow/api/middleware/middleware.go
+++ b/flow/api/middleware/middleware.go
@@ -1,10 +1,46 @@
 package middleware
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+
+	"flow/api/serde"
 )
+
+// RejectImpersonation blocks a route for admin impersonation sessions.
+//
+// The read-only guarantee for impersonation is enforced by Hasura, via the
+// `impersonated_user` role's select-only permissions. Handlers in this API,
+// however, talk to Postgres directly and never pass through Hasura, so a
+// route that writes on behalf of the caller has to opt into this middleware
+// or an impersonating admin would be able to modify the account after all.
+//
+// Requests with no token, or an invalid one, are passed through untouched:
+// deciding what to do about those is the handler's job, and it already does
+// it. This middleware only ever answers one question — is this a valid token
+// that happens to be impersonating.
+func RejectImpersonation() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims, err := serde.ClaimsFromRequest(r)
+			if err == nil && claims.Impersonating() {
+				serde.Error(w, r, serde.WithStatus(
+					http.StatusForbidden,
+					serde.WithEnum(
+						serde.ImpersonationForbidden,
+						fmt.Errorf("admin %d may not write to user %s while impersonating",
+							claims.Impersonator, claims.Hasura.UserId),
+					),
+				))
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
 
 // CORS middleware for localhost environments
 func CorsLocalhostMiddleware() func(http.Handler) http.Handler {

--- a/flow/api/serde/error.go
+++ b/flow/api/serde/error.go
@@ -43,6 +43,14 @@ const (
 	// Transcript contains no terms
 	EmptyTranscript = "empty_transcript"
 
+	//// Admin console
+	// Caller is authenticated but is not an admin
+	NotAdmin = "not_admin"
+	// Action is not allowed while impersonating another user
+	ImpersonationForbidden = "impersonation_forbidden"
+	// Impersonation target does not exist, or is an admin
+	InvalidImpersonationTarget = "invalid_impersonation_target"
+
 	//// Fallbacks
 	// These do not map exactly to 400 and 500 status codes respectively:
 	// - BadRequest represents all otherwise unidentified client errors

--- a/flow/api/serde/jwt.go
+++ b/flow/api/serde/jwt.go
@@ -13,6 +13,18 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+// Hasura roles this API mints tokens for.
+const (
+	// The role every ordinary session runs as: full read/write over the rows
+	// belonging to x-hasura-user-id.
+	UserRole = "user"
+	// The role an admin's impersonation session runs as. Its Hasura
+	// permissions mirror UserRole's select permissions exactly and grant no
+	// insert/update/delete, so an impersonated session can look at everything
+	// the user sees but cannot write anything to their account.
+	ImpersonatedUserRole = "impersonated_user"
+)
+
 type HasuraClaims struct {
 	AllowedRoles []string `json:"x-hasura-allowed-roles"`
 	DefaultRole  string   `json:"x-hasura-default-role"`
@@ -21,10 +33,45 @@ type HasuraClaims struct {
 
 type CombinedClaims struct {
 	Hasura HasuraClaims `json:"https://hasura.io/jwt/claims"`
+	// Set only on impersonation tokens: the id of the admin acting as the
+	// user named in Hasura.UserId. Hasura ignores this claim; it exists so the
+	// API can tell an impersonation session apart from a real one, attribute
+	// it to a person, and hand the admin their own identity back on exit.
+	Impersonator int `json:"imp,omitempty"`
 	jwt.RegisteredClaims
 }
 
+// Impersonating reports whether these claims describe an impersonation
+// session rather than a user's own login.
+func (c *CombinedClaims) Impersonating() bool {
+	return c.Impersonator != 0
+}
+
+// UserId is the id of the account the token acts on: the logged-in user
+// normally, or the impersonation target during an impersonation session.
+func (c *CombinedClaims) UserId() (int, error) {
+	userId, err := strconv.Atoi(c.Hasura.UserId)
+	if err != nil {
+		return 0, fmt.Errorf("invalid user id: %w", err)
+	}
+	return userId, nil
+}
+
 const ExpirationPeriod = 24 * time.Hour
+
+// Impersonation tokens live far shorter than ordinary sessions. An admin
+// looking at someone's account is doing a bounded piece of support work, and a
+// leaked or forgotten impersonation token should stop working the same day.
+const ImpersonationExpirationPeriod = 1 * time.Hour
+
+func signClaims(claims CombinedClaims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	jwtString, err := token.SignedString(env.Global.JwtKey)
+	if err != nil {
+		return "", err
+	}
+	return jwtString, nil
+}
 
 func NewSignedJwt(userId int) (string, error) {
 	now := time.Now()
@@ -36,52 +83,76 @@ func NewSignedJwt(userId int) (string, error) {
 			ExpiresAt: jwt.NewNumericDate(now.Add(ExpirationPeriod)),
 		},
 		Hasura: HasuraClaims{
-			AllowedRoles: []string{"user"},
-			DefaultRole:  "user",
+			AllowedRoles: []string{UserRole},
+			DefaultRole:  UserRole,
 			UserId:       strconv.Itoa(userId),
 		},
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	jwtString, err := token.SignedString(env.Global.JwtKey)
+	return signClaims(claims)
+}
 
-	if err != nil {
-		return "", err
+// NewImpersonationJwt mints a token that acts as targetUserId but is restricted
+// to the read-only ImpersonatedUserRole and attributed to adminUserId.
+//
+// ImpersonatedUserRole is the *only* allowed role on the token: Hasura lets a
+// client pick any role from x-hasura-allowed-roles via the x-hasura-role
+// header, so listing "user" here — even as a non-default — would let the
+// session simply ask for write access and get it.
+func NewImpersonationJwt(targetUserId int, adminUserId int) (string, error) {
+	now := time.Now()
+
+	claims := CombinedClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ImpersonationExpirationPeriod)),
+		},
+		Hasura: HasuraClaims{
+			AllowedRoles: []string{ImpersonatedUserRole},
+			DefaultRole:  ImpersonatedUserRole,
+			UserId:       strconv.Itoa(targetUserId),
+		},
+		Impersonator: adminUserId,
 	}
 
-	return jwtString, nil
+	return signClaims(claims)
 }
 
 func globalKey(t *jwt.Token) (interface{}, error) {
 	return env.Global.JwtKey, nil
 }
 
-func UserIdFromRequest(request *http.Request) (int, error) {
+// ClaimsFromRequest verifies the request's bearer token and returns its claims.
+func ClaimsFromRequest(request *http.Request) (*CombinedClaims, error) {
 	var tokenString string
 
 	if authStrings, ok := request.Header["Authorization"]; ok {
 		tokenString = strings.TrimPrefix(authStrings[0], "Bearer ")
 	} else {
-		return 0, fmt.Errorf("no authorization header")
+		return nil, fmt.Errorf("no authorization header")
 	}
 
 	token, err := jwt.ParseWithClaims(tokenString, new(CombinedClaims), globalKey)
 	if err != nil {
 		if errors.Is(err, jwt.ErrTokenExpired) {
-			return 0, WithEnum(ExpiredJwt, fmt.Errorf("expired token"))
+			return nil, WithEnum(ExpiredJwt, fmt.Errorf("expired token"))
 		}
 		if errors.Is(err, jwt.ErrTokenMalformed) {
-			return 0, fmt.Errorf("malformed token: %w", err)
+			return nil, fmt.Errorf("malformed token: %w", err)
 		}
-		return 0, fmt.Errorf("invalid token: %w", err)
+		return nil, fmt.Errorf("invalid token: %w", err)
 	}
 
 	// This will work because ParseWithClaims encountered no error
-	claims := token.Claims.(*CombinedClaims)
-	userId, err := strconv.Atoi(claims.Hasura.UserId)
+	return token.Claims.(*CombinedClaims), nil
+}
+
+func UserIdFromRequest(request *http.Request) (int, error) {
+	claims, err := ClaimsFromRequest(request)
 	if err != nil {
-		return 0, fmt.Errorf("invalid user id: %w", err)
+		return 0, err
 	}
 
-	return userId, nil
+	return claims.UserId()
 }

--- a/flow/api/serde/jwt_test.go
+++ b/flow/api/serde/jwt_test.go
@@ -1,0 +1,180 @@
+package serde
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"flow/api/env"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// The claims these tests assert on are the whole of the impersonation security
+// boundary: Hasura decides what a session may do purely from the role and user
+// id inside the token, so a regression here is not a cosmetic one.
+
+func init() {
+	env.Global.JwtKey = []byte("test-key-for-jwt-signing")
+}
+
+func requestWithToken(token string) *http.Request {
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	return r
+}
+
+func TestNewSignedJwtIsNotImpersonating(t *testing.T) {
+	token, err := NewSignedJwt(42)
+	if err != nil {
+		t.Fatalf("signing jwt: %s", err)
+	}
+
+	claims, err := ClaimsFromRequest(requestWithToken(token))
+	if err != nil {
+		t.Fatalf("parsing claims: %s", err)
+	}
+
+	if claims.Impersonating() {
+		t.Error("an ordinary login token reports itself as an impersonation session")
+	}
+	if claims.Hasura.DefaultRole != UserRole {
+		t.Errorf("default role = %q, want %q", claims.Hasura.DefaultRole, UserRole)
+	}
+
+	userId, err := claims.UserId()
+	if err != nil {
+		t.Fatalf("reading user id: %s", err)
+	}
+	if userId != 42 {
+		t.Errorf("user id = %d, want 42", userId)
+	}
+}
+
+func TestImpersonationJwtActsAsTargetUnderReadOnlyRole(t *testing.T) {
+	token, err := NewImpersonationJwt(7, 99)
+	if err != nil {
+		t.Fatalf("signing impersonation jwt: %s", err)
+	}
+
+	claims, err := ClaimsFromRequest(requestWithToken(token))
+	if err != nil {
+		t.Fatalf("parsing claims: %s", err)
+	}
+
+	userId, err := claims.UserId()
+	if err != nil {
+		t.Fatalf("reading user id: %s", err)
+	}
+	// The token must act as the target, not the admin: this is what makes every
+	// existing row-level Hasura filter resolve to the impersonated account.
+	if userId != 7 {
+		t.Errorf("user id = %d, want 7 (the impersonation target)", userId)
+	}
+
+	if !claims.Impersonating() {
+		t.Error("impersonation token does not report itself as one")
+	}
+	if claims.Impersonator != 99 {
+		t.Errorf("impersonator = %d, want 99 (the admin)", claims.Impersonator)
+	}
+	if claims.Hasura.DefaultRole != ImpersonatedUserRole {
+		t.Errorf("default role = %q, want %q", claims.Hasura.DefaultRole, ImpersonatedUserRole)
+	}
+}
+
+// Hasura lets a client select any role listed in x-hasura-allowed-roles by
+// sending an x-hasura-role header. If "user" ever appears alongside
+// "impersonated_user", an impersonation session can simply ask for write
+// access and Hasura will grant it — the read-only guarantee would be a
+// suggestion. This is the single most load-bearing assertion in the package.
+func TestImpersonationJwtAllowsOnlyTheReadOnlyRole(t *testing.T) {
+	token, err := NewImpersonationJwt(7, 99)
+	if err != nil {
+		t.Fatalf("signing impersonation jwt: %s", err)
+	}
+
+	claims, err := ClaimsFromRequest(requestWithToken(token))
+	if err != nil {
+		t.Fatalf("parsing claims: %s", err)
+	}
+
+	if len(claims.Hasura.AllowedRoles) != 1 {
+		t.Fatalf("allowed roles = %v, want exactly one", claims.Hasura.AllowedRoles)
+	}
+	if claims.Hasura.AllowedRoles[0] != ImpersonatedUserRole {
+		t.Errorf("allowed role = %q, want %q", claims.Hasura.AllowedRoles[0], ImpersonatedUserRole)
+	}
+}
+
+func TestImpersonationJwtExpiresSoonerThanALogin(t *testing.T) {
+	if ImpersonationExpirationPeriod >= ExpirationPeriod {
+		t.Fatalf(
+			"impersonation lifetime (%s) must be shorter than a login's (%s)",
+			ImpersonationExpirationPeriod, ExpirationPeriod,
+		)
+	}
+
+	token, err := NewImpersonationJwt(7, 99)
+	if err != nil {
+		t.Fatalf("signing impersonation jwt: %s", err)
+	}
+
+	claims, err := ClaimsFromRequest(requestWithToken(token))
+	if err != nil {
+		t.Fatalf("parsing claims: %s", err)
+	}
+
+	lifetime := claims.ExpiresAt.Sub(claims.IssuedAt.Time)
+	if lifetime != ImpersonationExpirationPeriod {
+		t.Errorf("lifetime = %s, want %s", lifetime, ImpersonationExpirationPeriod)
+	}
+}
+
+func TestExpiredTokenIsRejected(t *testing.T) {
+	// Signed the same way a real impersonation token is, but dated so that its
+	// one-hour window has already closed.
+	issuedAt := time.Now().Add(-2 * time.Hour)
+	token, err := signClaims(CombinedClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(issuedAt),
+			NotBefore: jwt.NewNumericDate(issuedAt),
+			ExpiresAt: jwt.NewNumericDate(issuedAt.Add(ImpersonationExpirationPeriod)),
+		},
+		Hasura: HasuraClaims{
+			AllowedRoles: []string{ImpersonatedUserRole},
+			DefaultRole:  ImpersonatedUserRole,
+			UserId:       "7",
+		},
+		Impersonator: 99,
+	})
+	if err != nil {
+		t.Fatalf("signing impersonation jwt: %s", err)
+	}
+
+	if _, err := ClaimsFromRequest(requestWithToken(token)); err == nil {
+		t.Error("an expired token was accepted")
+	}
+}
+
+func TestTokenSignedWithAnotherKeyIsRejected(t *testing.T) {
+	token, err := NewImpersonationJwt(7, 99)
+	if err != nil {
+		t.Fatalf("signing impersonation jwt: %s", err)
+	}
+
+	original := env.Global.JwtKey
+	defer func() { env.Global.JwtKey = original }()
+	env.Global.JwtKey = []byte("a-completely-different-key")
+
+	if _, err := ClaimsFromRequest(requestWithToken(token)); err == nil {
+		t.Error("a token signed with a different key was accepted")
+	}
+}
+
+func TestRequestWithoutAuthorizationHeaderIsRejected(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/", nil)
+	if _, err := ClaimsFromRequest(r); err == nil {
+		t.Error("a request with no Authorization header was accepted")
+	}
+}

--- a/hasura/README.md
+++ b/hasura/README.md
@@ -58,6 +58,35 @@ $ curl -H 'x-hasura-admin-secret:secretinprod' http://localhost:8080/v1/graphql 
 ```
 will submit the contents of the file `payload` and get the response.
 
+## Roles
+
+Three roles exist, and every table's metadata declares its permissions explicitly:
+
+| Role | Who gets it | Permissions |
+|---|---|---|
+| `anonymous` | logged-out visitors (`HASURA_GRAPHQL_UNAUTHORIZED_ROLE`) | select, on public course/prof data |
+| `user` | any signed-in user | select/insert/update/delete, scoped to `X-Hasura-User-Id` |
+| `impersonated_user` | an admin viewing another account through the admin console | **select only**, scoped to `X-Hasura-User-Id` |
+
+`impersonated_user` is what makes admin impersonation read-only. Its select
+permissions are a verbatim copy of `user`'s on every table, and it has **no**
+insert/update/delete permission anywhere — Hasura consequently exposes no
+mutation root to it at all, so a write is rejected as "no mutations exist"
+rather than table by table.
+
+> **When you change a `user` select permission, mirror it to
+> `impersonated_user` in the same file.** They are separate blocks in the same
+> `select_permissions` list, so nothing enforces this automatically: a column
+> added to `user` alone silently becomes invisible to an admin looking at the
+> account, and a *filter* relaxed on `user` alone leaves the two roles seeing
+> different rows. Never mirror insert/update/delete — that is exactly the
+> boundary the role exists to draw.
+
+Because these are two distinct roles rather than one inheriting from the other,
+be aware that Hasura's `inherited_roles` would *not* work here: in v2 an
+inherited role inherits mutation permissions along with select ones, so a role
+inheriting from `user` would be fully writable.
+
 ## Creating New Database Migrations
 
 The following steps are based on the [Hasura migration documentation](https://hasura.io/docs/latest/graphql/core/migrations/migrations-setup.html). We also assume the Hasura CLI is installed.

--- a/hasura/metadata/databases/default/tables/aggregate_course_easy_buckets.yaml
+++ b/hasura/metadata/databases/default/tables/aggregate_course_easy_buckets.yaml
@@ -10,6 +10,14 @@ select_permissions:
         - count
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_id
+        - value
+        - count
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/aggregate_course_rating.yaml
+++ b/hasura/metadata/databases/default/tables/aggregate_course_rating.yaml
@@ -13,6 +13,17 @@ select_permissions:
         - useful
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_id
+        - filled_count
+        - comment_count
+        - liked
+        - easy
+        - useful
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/aggregate_course_review_rating.yaml
+++ b/hasura/metadata/databases/default/tables/aggregate_course_review_rating.yaml
@@ -9,6 +9,13 @@ select_permissions:
         - upvote_count
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - review_id
+        - upvote_count
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/aggregate_course_useful_buckets.yaml
+++ b/hasura/metadata/databases/default/tables/aggregate_course_useful_buckets.yaml
@@ -10,6 +10,14 @@ select_permissions:
         - count
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_id
+        - value
+        - count
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/aggregate_prof_clear_buckets.yaml
+++ b/hasura/metadata/databases/default/tables/aggregate_prof_clear_buckets.yaml
@@ -10,6 +10,14 @@ select_permissions:
         - count
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - prof_id
+        - value
+        - count
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/aggregate_prof_engaging_buckets.yaml
+++ b/hasura/metadata/databases/default/tables/aggregate_prof_engaging_buckets.yaml
@@ -10,6 +10,14 @@ select_permissions:
         - count
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - prof_id
+        - value
+        - count
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/aggregate_prof_rating.yaml
+++ b/hasura/metadata/databases/default/tables/aggregate_prof_rating.yaml
@@ -13,6 +13,17 @@ select_permissions:
         - liked
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - prof_id
+        - filled_count
+        - comment_count
+        - clear
+        - engaging
+        - liked
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/aggregate_prof_review_rating.yaml
+++ b/hasura/metadata/databases/default/tables/aggregate_prof_review_rating.yaml
@@ -9,6 +9,13 @@ select_permissions:
         - upvote_count
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - review_id
+        - upvote_count
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_course.yaml
+++ b/hasura/metadata/databases/default/tables/public_course.yaml
@@ -88,6 +88,17 @@ select_permissions:
         - coreqs
         - antireqs
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - id
+        - antireqs
+        - code
+        - coreqs
+        - description
+        - name
+        - prereqs
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_course_antirequisite.yaml
+++ b/hasura/metadata/databases/default/tables/public_course_antirequisite.yaml
@@ -15,6 +15,12 @@ select_permissions:
         - course_id
         - antirequisite_id
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_id
+        - antirequisite_id
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_course_postrequisite.yaml
+++ b/hasura/metadata/databases/default/tables/public_course_postrequisite.yaml
@@ -28,6 +28,13 @@ select_permissions:
         - postrequisite_id
         - is_corequisite
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_id
+        - postrequisite_id
+        - is_corequisite
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_course_prerequisite.yaml
+++ b/hasura/metadata/databases/default/tables/public_course_prerequisite.yaml
@@ -16,6 +16,13 @@ select_permissions:
         - prerequisite_id
         - is_corequisite
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_id
+        - prerequisite_id
+        - is_corequisite
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_course_review_upvote.yaml
+++ b/hasura/metadata/databases/default/tables/public_course_review_upvote.yaml
@@ -11,6 +11,14 @@ insert_permissions:
         - review_id
         - user_id
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - review_id
+        - user_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_course_search_index.yaml
+++ b/hasura/metadata/databases/default/tables/public_course_search_index.yaml
@@ -19,6 +19,23 @@ select_permissions:
         - terms_with_online_sections
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - prof_ids
+        - terms
+        - terms_with_seats
+        - course_id
+        - ratings
+        - easy
+        - liked
+        - useful
+        - code
+        - name
+        - has_prereqs
+        - terms_with_online_sections 
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_course_section.yaml
+++ b/hasura/metadata/databases/default/tables/public_course_section.yaml
@@ -33,6 +33,18 @@ select_permissions:
         - term_id
         - updated_at
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - class_number
+        - course_id
+        - enrollment_capacity
+        - enrollment_total
+        - id
+        - section_name
+        - term_id
+        - updated_at
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_prof.yaml
+++ b/hasura/metadata/databases/default/tables/public_prof.yaml
@@ -55,6 +55,14 @@ select_permissions:
         - name
         - picture_url
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - id
+        - code
+        - name
+        - picture_url
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_prof_review_upvote.yaml
+++ b/hasura/metadata/databases/default/tables/public_prof_review_upvote.yaml
@@ -11,6 +11,14 @@ insert_permissions:
         - review_id
         - user_id
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - review_id
+        - user_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_prof_search_index.yaml
+++ b/hasura/metadata/databases/default/tables/public_prof_search_index.yaml
@@ -16,6 +16,20 @@ select_permissions:
         - code
       filter: {}
       allow_aggregations: true
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_ids
+        - course_codes
+        - prof_id
+        - ratings
+        - clear
+        - engaging
+        - liked
+        - name
+        - code
+      filter: {}
+      allow_aggregations: true
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_prof_teaches_course.yaml
+++ b/hasura/metadata/databases/default/tables/public_prof_teaches_course.yaml
@@ -27,6 +27,12 @@ select_permissions:
         - prof_id
         - course_id
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - prof_id
+        - course_id
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_review.yaml
+++ b/hasura/metadata/databases/default/tables/public_review.yaml
@@ -95,6 +95,23 @@ select_permissions:
         - created_at
         - updated_at
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - id
+        - course_id
+        - prof_id
+        - liked
+        - course_easy
+        - course_useful
+        - course_comment
+        - prof_clear
+        - prof_engaging
+        - prof_comment
+        - public
+        - created_at
+        - updated_at
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_review_author.yaml
+++ b/hasura/metadata/databases/default/tables/public_review_author.yaml
@@ -10,6 +10,14 @@ select_permissions:
         - program
         - picture_url
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - review_id
+        - full_name
+        - program
+        - picture_url
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_review_user_id.yaml
+++ b/hasura/metadata/databases/default/tables/public_review_user_id.yaml
@@ -2,6 +2,14 @@ table:
   name: review_user_id
   schema: public
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - review_id
+        - user_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_section_exam.yaml
+++ b/hasura/metadata/databases/default/tables/public_section_exam.yaml
@@ -13,6 +13,17 @@ select_permissions:
         - day
         - is_tba
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - section_id
+        - start_seconds
+        - end_seconds
+        - date
+        - location
+        - day
+        - is_tba
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_section_meeting.yaml
+++ b/hasura/metadata/databases/default/tables/public_section_meeting.yaml
@@ -21,6 +21,21 @@ select_permissions:
         - is_closed
         - is_tba
       filter: {}
+  - role: impersonated_user
+    permission:
+      columns:
+        - section_id
+        - prof_id
+        - start_seconds
+        - end_seconds
+        - start_date
+        - end_date
+        - location
+        - days
+        - is_cancelled
+        - is_closed
+        - is_tba
+      filter: {}
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_user.yaml
+++ b/hasura/metadata/databases/default/tables/public_user.yaml
@@ -31,6 +31,20 @@ array_relationships:
           name: user_shortlist
           schema: public
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - id
+        - secret_id
+        - email
+        - first_name
+        - last_name
+        - full_name
+        - picture_url
+        - program
+      filter:
+        id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_user_course_taken.yaml
+++ b/hasura/metadata/databases/default/tables/public_user_course_taken.yaml
@@ -6,6 +6,16 @@ object_relationships:
     using:
       foreign_key_constraint_on: course_id
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_id
+        - user_id
+        - term_id
+        - level
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_user_schedule.yaml
+++ b/hasura/metadata/databases/default/tables/public_user_schedule.yaml
@@ -9,6 +9,14 @@ object_relationships:
     using:
       foreign_key_constraint_on: user_id
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - user_id
+        - section_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_user_schedule_swap.yaml
+++ b/hasura/metadata/databases/default/tables/public_user_schedule_swap.yaml
@@ -21,6 +21,15 @@ insert_permissions:
         - source_section_id
         - user_id
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - replacement_section_id
+        - source_section_id
+        - user_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/public_user_shortlist.yaml
+++ b/hasura/metadata/databases/default/tables/public_user_shortlist.yaml
@@ -15,6 +15,14 @@ insert_permissions:
         - course_id
         - user_id
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - course_id
+        - user_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/metadata/databases/default/tables/queue_section_subscribed.yaml
+++ b/hasura/metadata/databases/default/tables/queue_section_subscribed.yaml
@@ -18,6 +18,14 @@ insert_permissions:
         - user_id
         - section_id
 select_permissions:
+  - role: impersonated_user
+    permission:
+      columns:
+        - user_id
+        - section_id
+      filter:
+        user_id:
+          _eq: X-Hasura-User-Id
   - role: user
     permission:
       columns:

--- a/hasura/migrations/default/1787895340080_admin_impersonation/down.sql
+++ b/hasura/migrations/default/1787895340080_admin_impersonation/down.sql
@@ -1,0 +1,5 @@
+DROP TABLE admin_impersonation_log;
+
+DROP INDEX user_is_admin_idx;
+
+ALTER TABLE "user" DROP COLUMN is_admin;

--- a/hasura/migrations/default/1787895340080_admin_impersonation/up.sql
+++ b/hasura/migrations/default/1787895340080_admin_impersonation/up.sql
@@ -1,0 +1,35 @@
+-- admin console: a flag marking staff accounts, and an append-only record of
+-- every impersonation session they open.
+
+ALTER TABLE "user" ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Admins are rare; a partial index keeps the "list all admins" lookup cheap
+-- without carrying an entry for every ordinary user.
+CREATE INDEX user_is_admin_idx ON "user"(id) WHERE is_admin;
+
+-- One row per impersonation session. Written before the token is handed out,
+-- so a session cannot exist without a record of it. `ended_at` is filled in
+-- when the admin exits deliberately; it stays NULL if they simply let the
+-- token expire, so absence of an end time is not an anomaly.
+CREATE TABLE admin_impersonation_log (
+  id SERIAL PRIMARY KEY,
+  admin_id INT NOT NULL
+    REFERENCES "user"(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  target_user_id INT NOT NULL
+    REFERENCES "user"(id)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE,
+  reason TEXT
+    CONSTRAINT admin_impersonation_log_reason_length CHECK (LENGTH(reason) <= 500),
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ended_at TIMESTAMPTZ
+);
+
+-- The console's default view is "most recent sessions first".
+CREATE INDEX admin_impersonation_log_started_at_idx
+  ON admin_impersonation_log(started_at DESC);
+
+CREATE INDEX admin_impersonation_log_admin_id_idx
+  ON admin_impersonation_log(admin_id);


### PR DESCRIPTION
## What

A staff-only admin console at `/admin` (frontend PR: UWFlow/uwflow_frontend) for searching users and viewing UW Flow **as** one of them — so an account-specific bug report can be reproduced without asking the person for screenshots or their password.

Requires the frontend PR to be usable; this half is the API, the Hasura role, and the migration.

## Impersonation is read-only, enforced by Hasura

A new `impersonated_user` role mirrors `user`'s select permissions on every table and holds **no** insert/update/delete anywhere. Hasura therefore exposes no mutation root to the role at all, so a write fails with `"no mutations exist"` rather than table by table.

> **Heads up for reviewers:** Hasura v2 `inherited_roles` looks like the obvious way to express this in four lines, but it does **not** work — an inherited role inherits mutation permissions along with select ones. I verified this against v2.25.1 before falling back to the explicit per-table mirror. `hasura/README.md` records the consequence: a `user` select permission change must be mirrored to `impersonated_user` in the same file, and insert/update/delete must never be.

## The rest of the containment

- **API routes too.** Handlers here talk to Postgres directly and never pass through Hasura, so the write endpoints (`/parse/*`, `DELETE /user`) are wrapped in `middleware.RejectImpersonation`. Any future route that writes on behalf of the caller belongs in that group in `api/main.go`.
- **No role escalation.** `impersonated_user` is the *only* entry in `x-hasura-allowed-roles`. Clients may select any allowed role via the `x-hasura-role` header, so listing `user` there — even as a non-default — would let the session simply ask for write access. There is a test pinning this.
- **Short-lived.** Tokens expire after an hour, and `/auth/refresh` refuses to renew them so the cap cannot be extended by staying logged in.
- **Audited.** Every session inserts into `admin_impersonation_log` *before* the token is minted, so a session cannot exist unrecorded. The console shows the log to all admins, not just its author.
- **Not chainable, not reflexive.** An impersonation token cannot open the console, and admins may impersonate neither themselves nor each other.

## Granting admin

`is_admin` is a new column on `"user"` with no self-service path:

```sh
docker exec postgres psql -U postgres -d $POSTGRES_DB \
  -c "UPDATE \"user\" SET is_admin = TRUE WHERE email = 'you@uwflow.com';"
```

## Endpoints

| Route | Purpose |
|---|---|
| `GET /admin/me` | whether the caller is an admin (gates the UI) |
| `GET /admin/users?q=` | search by name, email, or id |
| `POST /admin/impersonate` | start a session; records the audit row |
| `POST /admin/impersonate/stop` | end it, exchange for the admin's own token |
| `GET /admin/impersonation-log` | the audit trail |

## Known limitation

JWTs are stateless, so "Exit" closes the audit record and returns the admin's own token, but the impersonation token it replaces stays cryptographically valid until it expires. The one-hour lifetime is what bounds that window; genuine revocation would mean moving Hasura from JWT auth to webhook auth. Documented in the README.

## Testing

`go build`, `go vet`, `go test ./...` clean; new unit tests cover the token claims, the allowed-roles invariant, expiry, and signature rejection.

Verified end-to-end against a throwaway stack (separate ports and volume, so the shared dev database was untouched): the migration applies from scratch, every endpoint and guardrail behaves, and with a real impersonation JWT Hasura serves reads scoped to the target, rejects writes, and rejects an `x-hasura-role: user` escalation attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrJWMd1itog7bn3UfdNvg6