### PR TITLE
Add AI agent architecture guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-<!-- Generated: 2026-09-02 | Updated: 2026-09-02 -->
-
 # UWFlow backend
 
 This file is the canonical guide for coding agents working in this repository. `CLAUDE.md` is only an import shim. Read the relevant local `AGENTS.md` and linked style guide before changing a subsystem.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,84 @@
+<!-- Generated: 2026-09-02 | Updated: 2026-09-02 -->
+
+# UWFlow backend
+
+This file is the canonical guide for coding agents working in this repository. `CLAUDE.md` is only an import shim. Read the relevant local `AGENTS.md` and linked style guide before changing a subsystem.
+
+UWFlow is a small collection of services around one Postgres schema:
+
+```text
+Hasura migrations + metadata -> Postgres/GraphQL contract -> uwflow_frontend
+                                      ^
+                                      |
+                 Go API + UW importer + email worker
+                                      ^
+                                      |
+                           flow/common primitives
+```
+
+Changes on the left can affect every consumer to the right. Search the frontend repository when changing GraphQL fields, permissions, API routes or JSON, JWT claims, error codes, calendar output, or product-visible links.
+
+## Repository map
+
+| Path | Responsibility | Read before editing | Verify |
+| --- | --- | --- | --- |
+| `flow/api/` | Chi HTTP service for auth, parsing, calendar, and other non-CRUD operations | `flow/AGENTS.md`, `styleguide/backend-styleguide.md` | Focused `go test`, then `go test ./...` and `go build ./...` |
+| `flow/importer/uw/` | UW API ingestion: fetch, convert, stage, insert, and vacuum | `flow/AGENTS.md`, `styleguide/backend-styleguide.md` | Focused conversion tests; use mutation commands only with approval |
+| `flow/email/` | Database queue consumer, templates, and SMTP boundary | `flow/AGENTS.md`, `styleguide/backend-styleguide.md` | Focused tests plus build |
+| `flow/common/` | Infrastructure and utilities shared by multiple binaries | `flow/AGENTS.md` | Test every affected consumer |
+| `hasura/` | Schema migrations, relationships, permissions, and GraphQL metadata | `hasura/AGENTS.md`, `styleguide/backend-styleguide.md` | Apply up/down locally and inspect metadata |
+| `script/`, `nginx/`, `staging/` | Build, deployment, proxy, and Terraform operations | `styleguide/general-styleguide.md` | Inspect exact diff; never run destructive operations implicitly |
+
+## Core decisions
+
+- Ordinary data CRUD belongs in Hasura. Use the Go API for workflows, parsing, auth, calendar responses, or behavior Hasura cannot express cleanly.
+- Keep the current package-oriented architecture. Do not introduce repository/service/controller layers unless a concrete boundary is shared or independently testable.
+- Keep transport, transformation, and persistence separable. Handlers decode and validate, pure helpers transform, and database functions persist.
+- Put feature behavior in its owning package. Move code to `flow/common` only after at least two binaries need it and the abstraction contains no service-specific policy.
+- Preserve transaction ownership at the operation boundary. Leaf helpers accept `*db.Tx`; they do not begin or commit hidden transactions.
+- Treat Hasura permissions and metadata as security-critical application code.
+- Prefer the smallest complete change. Do not mix dependency, infrastructure, or architecture modernization into feature work.
+
+## Shared primitives
+
+This repository has no visual design system. Its equivalent reusable layer is semantic:
+
+- request/transaction adapters and public error mapping in `flow/api/serde/`;
+- context-aware database access in `flow/common/db/`;
+- shared runtime configuration in `flow/common/env/` and `flow/common/state/`;
+- repeatable migration and permission patterns in `hasura/`;
+- reusable email layout in `flow/email/format/`.
+
+Extend these when behavior is genuinely cross-cutting. Do not centralize endpoint-specific validation, importer policy, or presentation strings merely to remove a small amount of duplication.
+
+## Verification
+
+Run the narrowest useful check first, then the package or repository gate:
+
+| Change | Required checks |
+| --- | --- |
+| Go formatting or behavior | `gofmt` changed files; focused `go test`; `go test ./...`; `go build ./...` |
+| API contract | Above, plus search `../uwflow_frontend` for consumers |
+| Migration or metadata | Apply the migration locally, inspect metadata/permissions, test rollback, then check frontend codegen impact |
+| Import conversion | Table-driven tests with representative upstream fixtures |
+| Docker/build files | `make docker-build-test` when Docker is available |
+| Docs only | `git diff --check` and validate all referenced paths/commands |
+
+`make test` and `make build-test` run the Go checks inside the active API container. Direct commands run from `flow/` when Go is installed. Do not claim the legacy `regtest/` suite as a gate without first confirming its imports still match the current package layout.
+
+## Operational safety
+
+- Never commit `.env`, database dumps, `.ssl`, private keys, Terraform state, or credential-bearing output.
+- `make clean`, `make setup`, and `make setup-contrib` delete or replace local database/container state. Run them only when the user explicitly requests that outcome.
+- Import and vacuum commands mutate substantial data. Confirm the target environment and scope first.
+- Never run ad hoc tests against production. Staging replacement can destroy its database; review Terraform changes accordingly.
+- Existing migrations are immutable history. Add a new timestamped migration instead of editing an applied one.
+
+## Style guides
+
+- `styleguide/general-styleguide.md` — universal writing, change-scope, and safety conventions.
+- `styleguide/backend-styleguide.md` — Go, HTTP, database, Hasura, importer, and email patterns.
+- `flow/AGENTS.md` — Go module map and local rules.
+- `hasura/AGENTS.md` — schema and GraphQL contract checklist.
+
 @README.md

--- a/flow/AGENTS.md
+++ b/flow/AGENTS.md
@@ -1,0 +1,30 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-09-02 | Updated: 2026-09-02 -->
+
+# Go services
+
+## Purpose
+
+One Go module builds the API, UW importer, and email worker. `common/` provides infrastructure shared by those binaries.
+
+## Directory map
+
+| Directory | Responsibility |
+| --- | --- |
+| `api/` | Chi routes, auth, parsing, calendar/data endpoints, middleware, and response adapters |
+| `importer/uw/` | UW API client, schedule, conversion, staging, merge, and vacuum jobs |
+| `email/` | Queue processing, rendering, and SMTP delivery |
+| `common/db/` | Context-aware pgx pool and transaction wrappers |
+| `common/env/` | Environment loading shared across binaries |
+| `common/state/` | Process-level immutable/concurrency-safe dependencies |
+| `common/util/` | Small utilities with broad reuse |
+
+## For AI agents
+
+- Read `../styleguide/backend-styleguide.md` before changing Go behavior.
+- Keep feature policy out of `common/`; shared code must serve more than one binary and remain policy-neutral.
+- Adding a field to the shared environment affects every consumer. Update `.env.sample` and compose configuration together.
+- `api/parse/pdf/pdftotext.cc` is a native CGO bridge with Poppler build/runtime requirements. Verify changes in Docker.
+- Run commands from this directory: `gofmt` changed files, focused `go test`, then `go test ./...` and `go build ./...`.
+
+<!-- MANUAL: Add durable package-specific notes below this line. -->

--- a/flow/AGENTS.md
+++ b/flow/AGENTS.md
@@ -1,6 +1,3 @@
-<!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-09-02 | Updated: 2026-09-02 -->
-
 # Go services
 
 ## Purpose

--- a/hasura/AGENTS.md
+++ b/hasura/AGENTS.md
@@ -1,6 +1,3 @@
-<!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-09-02 | Updated: 2026-09-02 -->
-
 # Hasura schema and GraphQL contract
 
 ## Purpose

--- a/hasura/AGENTS.md
+++ b/hasura/AGENTS.md
@@ -1,0 +1,30 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-09-02 | Updated: 2026-09-02 -->
+
+# Hasura schema and GraphQL contract
+
+## Purpose
+
+This directory is the canonical relational schema and GraphQL authorization contract. Migrations define Postgres state; metadata defines GraphQL exposure, relationships, actions, and role permissions.
+
+## Key paths
+
+| Path | Responsibility |
+| --- | --- |
+| `migrations/default/` | Immutable timestamped forward and rollback SQL |
+| `metadata/databases/default/tables/` | Per-table relationships, permissions, and event configuration |
+| `metadata/databases/default/tables/tables.yaml` | Registration of per-table metadata files |
+| `metadata/actions.*` | Custom GraphQL action schema and handlers |
+| `config.yaml` | Hasura CLI project configuration |
+
+## For AI agents
+
+- Read `README.md` and `../styleguide/backend-styleguide.md` before making a schema change.
+- Create a new timestamped migration with `up.sql` and `down.sql`; never rewrite applied history.
+- Update registration, relationships, and every relevant role's select/insert/update/delete permissions.
+- Review constraints and indexes as part of the same change. Application validation does not replace database invariants.
+- Apply forward migration and metadata locally, exercise the affected query/mutation under realistic roles, then test rollback.
+- Search `../../uwflow_frontend/src/graphql` for consumers and regenerate frontend types when the schema contract changes.
+- Do not put secrets in metadata or migration files.
+
+<!-- MANUAL: Add durable schema-specific notes below this line. -->

--- a/styleguide/backend-styleguide.md
+++ b/styleguide/backend-styleguide.md
@@ -1,0 +1,71 @@
+# Backend style guide
+
+## Choose the owning layer
+
+```text
+Simple authorized CRUD or relationship query? -> Hasura
+Custom HTTP/auth/parsing/calendar workflow?    -> flow/api/<feature>
+UW source synchronization?                     -> flow/importer/uw
+Queued email composition or delivery?          -> flow/email
+Used by two or more Go binaries without policy? -> flow/common
+```
+
+Do not make the Go API a proxy for GraphQL CRUD. Do not put database mutation in parsing helpers or transport formatting in persistence helpers.
+
+## Go and HTTP
+
+- Pass `context.Context` from the request or job boundary into database and network work. Do not replace it with `context.Background()` below a boundary.
+- Register API routes centrally in `flow/api/main.go`; keep handler logic in the feature package.
+- Use `serde.WithDbResponse` or `serde.WithDbNoResponse` for transactional JSON operations. Use `serde.WithDbDirect` only when the handler must own a non-JSON response/body or its transaction lifecycle.
+- Decode and validate input before mutation. Keep transformations pure where possible so edge cases can be table-tested.
+- Preserve middleware order and the request timeout unless the change explicitly requires different semantics.
+- Use parameterized SQL only. Close or fully consume query rows and check iteration errors.
+
+## Transactions and concurrency
+
+- Begin, commit, and roll back at the operation boundary. A helper receiving `*db.Tx` participates in its caller's transaction.
+- Keep transactions short. Do not perform slow network or SMTP calls inside a transaction without understanding the retry and visibility behavior already expected by that workflow.
+- Preserve ordering, idempotency, and retry behavior in importer and email paths. A process retry must not silently duplicate externally visible work.
+- Shared state must be immutable after initialization or explicitly concurrency-safe.
+
+## Hasura and Postgres
+
+- Add schema changes under `hasura/migrations/default/<timestamp>_<name>/` with both `up.sql` and a meaningful `down.sql`.
+- Never edit the initial or another already-applied migration to represent a new change.
+- Update the matching per-table metadata plus the aggregate registration, relationships, and role permissions. A table exposed without deliberate permissions is incomplete.
+- Preserve constraints, indexes, triggers, functions, and dependent views in both directions. Materialized-view changes require reviewing the full dependency chain.
+- Use database constraints for durable invariants; application checks improve errors but do not replace concurrency-safe constraints.
+- Treat metadata exports as declarative source. Avoid manual changes that the next Hasura export will erase.
+
+## Importer
+
+- Maintain the fetch -> convert -> stage/copy -> merge structure under `flow/importer/uw/parts/`.
+- Network decoding and normalization should be testable without a database. Database functions consume normalized values.
+- Preserve explicit rules that protect manual or authoritative rows during vacuum and merge operations.
+- Prefer per-entity transaction boundaries so one failed import does not corrupt a batch. Report aggregate outcomes without hiding individual failures.
+- Use fixtures for upstream response shapes and table-driven tests for conversion edge cases.
+
+## Email
+
+- Keep queue scanning, message data, HTML rendering, and SMTP delivery in their existing packages.
+- Maintain retry/idempotency semantics when moving the point at which a queue item is marked processed.
+- Escape untrusted content in HTML and keep product-visible URLs configurable where the existing environment model supports it.
+- Test formatting independently from live SMTP delivery.
+
+## Testing patterns
+
+- Place focused `*_test.go` files with the owning package. Existing sibling `test` packages may remain; do not churn them solely for consistency.
+- Prefer table-driven cases with `t.Run` for parsers, conversions, validation, and status mapping.
+- Use `go-cmp` for structural output. Keep source documents in `testdata/` rather than embedding large fixtures in test code.
+- Tests must be deterministic: inject time, clients, or randomness when touching behavior that otherwise depends on them.
+- A bug fix should include a test that fails for the old behavior whenever the boundary is testable.
+
+## Cross-repository contract checklist
+
+When changing a public contract, search `../uwflow_frontend` and verify:
+
+- GraphQL documents and generated types for schema changes;
+- Apollo cache keys for identity or primary-key changes;
+- API endpoint paths, methods, JSON shapes, and stable error values;
+- JWT/auth behavior and Hasura role permissions;
+- calendar parsing/display assumptions and product-visible email links.

--- a/styleguide/general-styleguide.md
+++ b/styleguide/general-styleguide.md
@@ -1,0 +1,31 @@
+# General style guide
+
+## Change discipline
+
+- Read the owning package and its callers before editing. Follow established local shapes unless there is evidence they are causing the problem.
+- Prefer deletion, reuse, or extension before adding another helper or abstraction.
+- Keep refactors separate from behavior changes when practical. A review should be able to identify the intended behavior from the diff.
+- Do not upgrade unrelated dependencies, rewrite configuration, or reorganize directories opportunistically.
+- Preserve uncommitted user work and generated-file ownership.
+
+## Naming and comments
+
+- Use idiomatic Go names: short lower-case package names, PascalCase exported identifiers, and concise lowerCamelCase local names. Follow the existing lower-case or underscore-separated filename convention; TypeScript filename rules from the Rec monorepo do not apply here.
+- Name code so that it does not need narration. Comments explain a hidden constraint, invariant, external protocol, or surprising decision.
+- Keep comments plain and concise. Do not describe what the next line already says or record temporary implementation history.
+- Preserve useful protocol and data-preservation explanations, especially around calendar formats, SQL, auth, and concurrency.
+
+## Errors, logs, and secrets
+
+- Wrap errors with operation context using `%w` so callers retain the cause.
+- Return stable public status/enum information through `api/serde`; never expose raw database or internal error text.
+- Log enough context to identify the operation, never access tokens, credentials, private user payloads, or full auth requests.
+- Reserve `panic`, `log.Fatal`, and process exit for unrecoverable startup or top-level binary failures.
+
+## Definition of done
+
+- The change lives at the narrowest correct architectural boundary.
+- New behavior has a focused test or an explicit explanation of why automated coverage is impractical.
+- Changed Go is formatted and the affected package builds.
+- Public contracts and downstream consumers were checked.
+- Risky commands, generated files, and secrets were handled deliberately.


### PR DESCRIPTION
Add repository-specific architecture, Go, and Hasura guidance for coding agents.