### PR TITLE
Add private Supabase Studio for database administration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,16 @@ executors:
       ALL_IMAGES: neuwflow/api neuwflow/email neuwflow/uw
     machine: true
 jobs:
+  studio-test:
+    executor: docker-publisher
+    steps:
+      - checkout
+      - run:
+          name: Install Studio test prerequisites
+          command: sudo apt-get update && sudo apt-get install -y apache2-utils python3
+      - run:
+          name: Test private Studio against disposable PostgreSQL
+          command: python3 admin/studio/test.py
   build:
     executor: docker-publisher
     steps:
@@ -39,6 +49,7 @@ workflows:
   version: 2
   normal:
     jobs:
+      - studio-test
       - build
       - publish:
           requires:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environment files (contain secrets)
 .env
+admin/studio/.secrets/
 # SSL certificates
 .ssl
 # Air tmp directory (generated during live reload)
@@ -14,4 +15,3 @@ terraform.tfvars
 .terraform.lock.hcl
 # TLS certs/keys — never commit
 *.pem
-

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ In production, we run an Nginx reverse proxy in front of Hasura, the API, and th
 to route requests to the correct service. Hasura is exposed via `/graphql`, the API via `/api`,
 and the frontend via `/`.
 
+For optional, private Supabase Studio access to the existing database, see
+[the Studio admin setup](admin/studio/README.md). It does not replace Hasura or
+UWFlow authentication.
+
 ## Requirements
 
 The following packages are required for core functionality:
@@ -126,4 +130,3 @@ $ docker exec -it postgres sh
 ```
 
 There are other `make` commands available, use `make help` to explore them, or simply visit `Makefile`
-

--- a/admin/studio/README.md
+++ b/admin/studio/README.md
@@ -1,0 +1,183 @@
+# Private database administration with Supabase Studio
+
+This opt-in Compose overlay runs Studio, postgres-meta, and an authenticated
+Nginx gateway against UWFlow's existing stock PostgreSQL 15 database. It adds no
+Supabase database, Auth, PostgREST, Storage, Realtime, or public website route.
+Hasura remains responsible for application permissions and schema migrations;
+the Go API still issues UWFlow's user tokens.
+
+## Access and privilege boundaries
+
+The only new published port is `127.0.0.1:8001`. Access it through SSH and HTTP
+Basic authentication. **Self-hosted Studio does not authenticate its own API
+requests**: never publish Studio's port 3000 or postgres-meta's port 8080, or
+route around the gateway. The gateway authenticates every path, including SQL
+requests, and rejects unexpected Host, Origin, and cross-site fetch headers.
+Use exactly `http://localhost:8001` in the browser.
+
+Studio and the gateway share an internal Docker network with postgres-meta.
+Only postgres-meta also joins the separate internal network attached to
+Postgres. None of the three new services joins the application's default
+network. Studio and meta have no external network access; only the gateway has
+a separate routable network for localhost port publishing. All three run without
+root, Linux capabilities, or writable root filesystems. Docker administrators and trusted processes on the
+host remain inside the trust boundary. Use Docker Engine 28+ so localhost port
+publishing also blocks access from other hosts on the same L2 network.
+
+The dedicated `flow_studio` login inherits PostgreSQL's `pg_read_all_data` and
+`pg_write_all_data` roles: **this grants access to all application data, including
+private schemas and future tables**. Give access only to database administrators.
+Hasura permissions do not apply to this connection. It has no superuser,
+role-creation, database-creation, replication, or RLS-bypass privileges, and does
+not own application tables. Existing SQL functions keep their own permissions.
+The Studio read-only connection setting uses the same login; it is not an
+additional security boundary. This is a data administration tool, not a read-only
+viewer or a way to perform schema changes outside migrations.
+
+## Enable on an existing backend host
+
+Requirements: Docker Engine 28+, Docker Compose v2, `openssl`, and `htpasswd`
+(Debian/Ubuntu: `apache2-utils`). Take and verify a database backup first. Test
+against a restored non-production database before enabling production access.
+
+1. From the backend checkout, connect as the existing database administrator:
+
+   ```sh
+   docker compose exec postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
+   ```
+
+   Run the statements in [`create-role.sql`](create-role.sql) once, then run
+   `\password flow_studio`. Set a fresh password from `openssl rand -hex 32`
+   using the interactive prompt; do not put it in SQL history or shell arguments.
+   The script deliberately fails if the role already exists. Inspect its grants
+   before reusing an existing role rather than silently changing its privileges.
+
+2. Copy [`env.sample`](env.sample) to `admin/studio/.env`.
+   Set `STUDIO_DB_PASSWORD` to the password from step 1 and `STUDIO_CRYPTO_KEY`
+   to a separate `openssl rand -hex 32` value. Use hex values because Studio
+   embeds the password in a connection URI. Run `chmod 600 admin/studio/.env`.
+   Never reuse the database owner's password or Hasura secrets. Only these two
+   new secrets and the database name/port are passed to the admin services.
+   Do not put admin secrets in the backend's root `.env`, which is passed to
+   application containers. In that root `.env`, add only
+   `COMPOSE_FILE=docker-compose.yml:docker-compose.studio.yml` to enable the
+   overlay for subsequent deployments.
+
+3. Create a separate gateway login (interactive password prompt):
+
+   ```sh
+   mkdir -p admin/studio/.secrets
+   chmod 700 admin/studio/.secrets
+   htpasswd -cB admin/studio/.secrets/htpasswd YOUR_ADMIN_NAME
+   chmod 644 admin/studio/.secrets/htpasswd
+   ```
+
+   The directory prevents other host users from reading the hash file; the file
+   is readable inside the non-root proxy's read-only mount. Add further named
+   administrators with `htpasswd -B` (omit `-c`, which replaces the file). Use
+   distinct strong passwords. The `.secrets` directory is gitignored.
+
+4. Validate and pull the three pinned images:
+
+   ```sh
+   docker compose config --quiet
+   docker compose pull studio studio-meta studio-proxy
+   ```
+
+   Avoid printing full resolved Compose config, which contains secrets. The
+   overlay requires both secret files to exist. Its entrypoint rejects missing,
+   malformed, or identical secrets before starting Studio or meta.
+
+5. Schedule a brief backend maintenance window for the first start:
+
+   ```sh
+   docker compose up -d postgres
+   docker compose up -d --wait studio-proxy
+   ```
+
+   The first command recreates the existing Postgres container to attach its new
+   network; it preserves the existing image, command, database volume, and ports.
+   It can interrupt database connections. The second starts all admin services.
+   Keep `COMPOSE_FILE=docker-compose.yml:docker-compose.studio.yml` in `.env` so
+   subsequent Compose operations, including `script/deploy.sh`, preserve the
+   Postgres network. For local development include `docker-compose.dev.yml` too.
+   The normal deploy script updates only the app services; admin image upgrades
+   use the explicit commands below.
+
+6. On your workstation, open a tunnel and keep it running:
+
+   ```sh
+   ssh -N -o ExitOnForwardFailure=yes -L 127.0.0.1:8001:127.0.0.1:8001 ADMIN@BACKEND_HOST
+   ```
+
+   Visit `http://localhost:8001`, enter the gateway credentials, and open the
+   table or SQL editor. SSH encrypts the remote connection. Do not expose this
+   HTTP Basic-auth endpoint on a public interface or proxy it through UWFlow's
+   public Nginx. Close the browser session and SSH tunnel when finished.
+
+## What works, and what stays in Hasura
+
+Use table discovery, row reads/edits, and SQL with the dedicated role. Database
+RLS, constraints, and triggers still apply. Run `SELECT current_user` in the SQL
+editor to confirm `flow_studio`. Schema/role changes and some Studio monitoring
+queries require higher privileges and may fail; do not grant superuser to make
+those panels work. Run schema changes through tracked Hasura migrations, then
+update metadata where needed.
+
+Supabase-specific Auth, Storage, Realtime, logs, API documentation, extensions,
+and advisor panels are not supported by this deployment. Do not follow Studio
+prompts to install Supabase schemas or grant client roles access to UWFlow data.
+Saved SQL snippets are temporary and disappear when Studio is recreated; store
+reviewable SQL in the repository. No AI provider key is configured.
+
+This overlay does not change pre-existing host bindings for Postgres, Hasura,
+or the Go API. Their existing firewall and ingress restrictions still need to
+be maintained; a private Studio gateway does not protect a separately exposed
+database port.
+
+## Verification
+
+Run `python3 admin/studio/test.py` from a development checkout. It uses the actual
+overlay with a disposable stock PostgreSQL 15 database, random credentials, and
+a random Compose project. Port 8001 must be free. It checks unauthenticated and
+wrong-password rejection, Host/Origin protection, table discovery, a SQL
+read/update/read round trip, RLS enforcement, and rejected privilege escalation
+and table deletion. It removes only its test project and uses no production data.
+
+On the deployed host, verify `docker compose ps` publishes only
+`127.0.0.1:8001` for the gateway and no ports for Studio/meta. Through the tunnel:
+
+```sh
+curl -i http://localhost:8001/api/platform/projects
+curl --user YOUR_ADMIN_NAME http://localhost:8001/api/platform/projects
+```
+
+Expect 401 without credentials and 200 after the second command's password
+prompt. Inspect the table editor yourself for visual acceptance; automated
+verification uses terminal HTTP/SQL checks only.
+
+## Rotation, upgrades, and removal
+
+- Rotate a gateway password with `htpasswd -B`, then recreate `studio-proxy` so
+  its bind mount sees the replaced file. Disable an administrator with
+  `htpasswd -D` and the same recreation.
+- Rotate the database password with `\password flow_studio`, update `admin/studio/.env`, then
+  recreate Studio and postgres-meta. Rotate `STUDIO_CRYPTO_KEY` in both services
+  together. Never copy these credentials into frontend configuration.
+- Studio and postgres-meta tags and multi-platform digests are pinned together
+  from the upstream Docker configuration. Review release/security notes, update
+  pins deliberately, and rerun the integration test before upgrading. Pull and
+  run `docker compose up -d --wait studio-proxy` with the overlay enabled.
+- To disable access, run `docker compose stop studio-proxy studio studio-meta`.
+  To remove the containers, run `docker compose rm -f studio-proxy studio studio-meta`
+  after stopping them. Remove the Studio entries from `.env` and recreate
+  Postgres in a maintenance window to detach its admin network. As DB admin,
+  terminate remaining `flow_studio` sessions, revoke its grants, and drop the
+  login when no longer needed. Remove `admin/studio/.env` and the gateway hash
+  file after revoking access. Preserve the normal PostgreSQL volume and backups;
+  do not use `docker compose down -v` on the backend.
+
+References: [upstream Docker configuration](https://github.com/supabase/supabase/blob/master/docker/docker-compose.yml),
+[Studio privilege configuration](https://supabase.com/docs/guides/self-hosting/remove-superuser-access),
+[PostgreSQL predefined roles](https://www.postgresql.org/docs/15/predefined-roles.html),
+[Docker port publishing](https://docs.docker.com/engine/network/port-publishing/).

--- a/admin/studio/create-role.sql
+++ b/admin/studio/create-role.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP on
+-- Run once as the existing DB administrator, then use \password flow_studio.
+-- Passwords must not appear in migrations, shell arguments, or SQL logs.
+CREATE ROLE flow_studio LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE
+    NOREPLICATION NOBYPASSRLS CONNECTION LIMIT 10;
+GRANT pg_read_all_data, pg_write_all_data TO flow_studio;
+SELECT format('GRANT CONNECT ON DATABASE %I TO flow_studio', current_database()) \gexec
+ALTER ROLE flow_studio SET statement_timeout = '30s';
+ALTER ROLE flow_studio SET idle_in_transaction_session_timeout = '60s';

--- a/admin/studio/entrypoint.sh
+++ b/admin/studio/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+# Do not source an env file as shell code or print secret values on failure.
+for value in "${STUDIO_DB_PASSWORD:-}" "${STUDIO_CRYPTO_KEY:-}"; do
+    case "$value" in
+        ''|*[!0-9a-fA-F]*) echo 'Studio secrets must be generated with openssl rand -hex 32' >&2; exit 1 ;;
+    esac
+    [ "${#value}" -eq 64 ] || { echo 'Studio secrets must contain 64 hex characters' >&2; exit 1; }
+done
+[ "$STUDIO_DB_PASSWORD" != "$STUDIO_CRYPTO_KEY" ] || { echo 'Use independent Studio secrets' >&2; exit 1; }
+export POSTGRES_PASSWORD="$STUDIO_DB_PASSWORD" PG_META_DB_PASSWORD="$STUDIO_DB_PASSWORD"
+export PG_META_CRYPTO_KEY="$STUDIO_CRYPTO_KEY" CRYPTO_KEY="$STUDIO_CRYPTO_KEY"
+unset STUDIO_DB_PASSWORD STUDIO_CRYPTO_KEY value
+exec "$@"

--- a/admin/studio/env.sample
+++ b/admin/studio/env.sample
@@ -1,0 +1,5 @@
+# Copy to admin/studio/.env (chmod 600). Only Studio and meta load this file.
+# Generate separate values with `openssl rand -hex 32` twice. Never reuse
+# POSTGRES_PASSWORD, HASURA_GRAPHQL_JWT_KEY, or HASURA_GRAPHQL_ADMIN_SECRET.
+STUDIO_DB_PASSWORD=
+STUDIO_CRYPTO_KEY=

--- a/admin/studio/nginx.conf
+++ b/admin/studio/nginx.conf
@@ -1,0 +1,50 @@
+worker_processes auto;
+pid /tmp/nginx.pid;
+error_log /dev/stderr warn;
+events { worker_connections 512; }
+http {
+    server_tokens off;
+    access_log /dev/stdout;
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    # Reject DNS rebinding and cross-origin requests carrying cached Basic auth.
+    map $http_host $allowed_host {
+        default 0;
+        "localhost:8001" 1;
+    }
+    map $http_origin $allowed_origin {
+        default 0;
+        "" 1;
+        "http://localhost:8001" 1;
+    }
+    server {
+        listen 8080;
+        if ($allowed_host = 0) { return 403; }
+        if ($allowed_origin = 0) { return 403; }
+        if ($http_sec_fetch_site = "cross-site") { return 403; }
+        auth_basic "UWFlow database administration";
+        auth_basic_user_file /etc/nginx/studio.htpasswd;
+        client_max_body_size 10m;
+        add_header X-Frame-Options DENY always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy no-referrer always;
+        add_header Cache-Control no-store always;
+        location / {
+            # Docker DNS must be resolved again after a Studio container update.
+            resolver 127.0.0.11 valid=10s ipv6=off;
+            set $studio_upstream http://studio:3000;
+            proxy_pass $studio_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header Authorization "";
+            proxy_set_header Connection "";
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-Proto http;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_read_timeout 60s;
+        }
+    }
+}

--- a/admin/studio/test.py
+++ b/admin/studio/test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Exercise the real admin gateway and Studio against disposable PostgreSQL 15.
+
+Requires Python 3, Docker Compose v2+, and htpasswd. No production env/data used.
+"""
+import base64
+import json
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run(*args, **kwargs):
+    return subprocess.run(args, check=True, text=True, capture_output=True, **kwargs).stdout
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="uwflow-studio-test-") as directory:
+        temp = Path(directory)
+        password = secrets.token_hex(32)
+        web_password = secrets.token_hex(24)
+        auth_file = temp / "htpasswd"
+        auth_file.write_text(run("htpasswd", "-niB", "test-admin", input=web_password + "\n"))
+        auth_file.chmod(0o644)
+        env_file = temp / ".env"
+        env_file.touch()
+        studio_env = temp / "studio.env"
+        studio_env.write_text("STUDIO_DB_PASSWORD=" + password + "\nSTUDIO_CRYPTO_KEY="
+                              + secrets.token_hex(32) + "\n")
+        studio_env.chmod(0o600)
+        base = temp / "base.json"
+        base.write_text(json.dumps({"services": {"postgres": {
+            "image": "postgres:15-alpine",
+            "environment": {"POSTGRES_PASSWORD": password, "POSTGRES_DB": "studio_test"},
+            "tmpfs": ["/var/lib/postgresql/data"],
+            "healthcheck": {"test": ["CMD", "pg_isready", "-U", "postgres"],
+                            "interval": "2s", "timeout": "2s", "retries": 30}
+        }}}))
+        override = temp / "override.json"
+        override.write_text(json.dumps({"services": {"studio-proxy": {"volumes": [{
+            "type": "bind", "source": str(auth_file),
+            "target": "/etc/nginx/studio.htpasswd", "read_only": True
+        }]}}}))
+        env = {**os.environ, "POSTGRES_PORT": "5432", "POSTGRES_DB": "studio_test",
+               "STUDIO_ENV_FILE": str(studio_env)}
+        # Explicit files/project/env prevent touching the normal backend stack.
+        compose = ["docker", "compose", "--project-name", "uwflow-studio-test-" + secrets.token_hex(4),
+                   "--project-directory", str(ROOT), "--env-file", str(env_file),
+                   "-f", str(base), "-f", str(ROOT / "docker-compose.studio.yml"), "-f", str(override)]
+
+        def dc(*args, **kwargs):
+            return run(*compose, *args, env=env, **kwargs)
+
+        def sql(query):
+            return dc("exec", "-T", "postgres", "psql", "-v", "ON_ERROR_STOP=1",
+                      "-U", "postgres", "-d", "studio_test", input=query)
+
+        def request(path, payload=None, authenticated=True, headers=None):
+            values = {"Host": "localhost:8001", **(headers or {})}
+            if authenticated:
+                values["Authorization"] = "Basic " + base64.b64encode(
+                    ("test-admin:" + web_password).encode()).decode()
+            data = None if payload is None else json.dumps(payload).encode()
+            if data is not None:
+                values["Content-Type"] = "application/json"
+            req = urllib.request.Request("http://127.0.0.1:8001" + path, data=data, headers=values)
+            try:
+                with urllib.request.urlopen(req, timeout=65) as response:
+                    return response.status, response.read().decode()
+            except urllib.error.HTTPError as error:
+                return error.code, error.read().decode()
+
+        try:
+            # Configuration security invariants are checked before starting anything.
+            config = json.loads(dc("config", "--format", "json"))
+            services = config["services"]
+            assert not services["studio"].get("ports")
+            assert not services["studio-meta"].get("ports")
+            assert services["studio-proxy"]["ports"][0]["host_ip"] == "127.0.0.1"
+            for name in ("studio", "studio-meta", "studio-proxy"):
+                assert "default" not in services[name]["networks"]
+            assert config["networks"]["studio-web"]["internal"]
+            assert config["networks"]["studio-db"]["internal"]
+            # Missing/default/equal secrets must fail before either app starts.
+            for bad_env in ({}, {"STUDIO_DB_PASSWORD": "default", "STUDIO_CRYPTO_KEY": "default"},
+                            {"STUDIO_DB_PASSWORD": "a" * 64, "STUDIO_CRYPTO_KEY": "a" * 64}):
+                result = subprocess.run(["sh", str(ROOT / "admin/studio/entrypoint.sh"), "true"],
+                                        env={"PATH": os.environ["PATH"], **bad_env}, capture_output=True)
+                assert result.returncode != 0
+            dc("up", "-d", "--wait", "postgres")
+            sql((ROOT / "admin/studio/create-role.sql").read_text())
+            sql("ALTER ROLE flow_studio PASSWORD '" + password + "';\n"
+                "CREATE TABLE public.studio_fixture (id integer PRIMARY KEY, value text);\n"
+                "INSERT INTO public.studio_fixture VALUES (1, 'before');\n"
+                "CREATE TABLE public.studio_rls_fixture (id integer);\n"
+                "ALTER TABLE public.studio_rls_fixture ENABLE ROW LEVEL SECURITY;\n"
+                "INSERT INTO public.studio_rls_fixture VALUES (1);\n")
+            dc("up", "-d", "--wait", "--wait-timeout", "180", "studio-proxy")
+            query_path = "/api/platform/pg-meta/default/query"
+            for path in ("/", "/api/platform/projects", query_path):
+                assert request(path, authenticated=False)[0] == 401, path
+                assert request(path, authenticated=False,
+                               headers={"Authorization": "Basic d3Jvbmc6d3Jvbmc="})[0] == 401, path
+            for headers in ({"Host": "attacker.example"}, {"Origin": "https://attacker.example"},
+                            {"Sec-Fetch-Site": "cross-site"}):
+                assert request(query_path, {"query": "SELECT 1"}, headers=headers)[0] == 403
+            assert request("/project/default/editor")[0] == 200
+            assert request("/api/platform/projects")[0] == 200
+
+            def query(statement):
+                status, body = request(query_path, {"query": statement})
+                assert status == 200, (status, body)
+                return json.loads(body)
+
+            assert query("SELECT current_user AS name")[0]["name"] == "flow_studio"
+            assert query("SELECT value FROM public.studio_fixture")[0]["value"] == "before"
+            query("UPDATE public.studio_fixture SET value = 'after' WHERE id = 1")
+            assert query("SELECT value FROM public.studio_fixture")[0]["value"] == "after"
+            assert query("SELECT * FROM public.studio_rls_fixture") == []
+            for statement in ("ALTER ROLE flow_studio SUPERUSER",
+                              "DROP TABLE public.studio_fixture"):
+                status, _ = request(query_path, {"query": statement})
+                assert status >= 400, statement
+            # Exercise the endpoint used to populate the table browser as well as SQL.
+            status, body = request("/api/platform/pg-meta/default/tables?included_schemas=public")
+            assert status == 200 and "studio_fixture" in body, (status, body)
+            print("PASS: gateway auth/origin checks, Studio table discovery, SQL read/write, RLS and role restrictions")
+        except Exception:
+            print(dc("logs", "--tail", "30", "studio", "studio-meta", "studio-proxy"))
+            raise
+        finally:
+            # Only this random project is removed; its database lives in tmpfs.
+            dc("down", "--volumes", "--remove-orphans")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.studio.yml
+++ b/docker-compose.studio.yml
@@ -1,0 +1,115 @@
+# Opt-in overlay: see admin/studio/README.md. Keep this file in COMPOSE_FILE
+# for subsequent backend deployments so Postgres retains its admin network.
+services:
+  postgres:
+    networks:
+      default:
+      studio-db:
+
+  studio:
+    image: supabase/studio:2026.08.03-sha-022b374@sha256:606aca9fdaa753b60968d5c304e2ada83869b76c9043684e63d5885aca9550e8
+    restart: unless-stopped
+    user: "1000:1000"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    tmpfs:
+      - /tmp
+    env_file: ${STUDIO_ENV_FILE:-./admin/studio/.env}
+    entrypoint: [/bin/sh, /studio-entrypoint.sh]
+    command: [node, apps/studio/server.js]
+    volumes:
+      - ./admin/studio/entrypoint.sh:/studio-entrypoint.sh:ro
+    networks: [studio-web]
+    depends_on:
+      studio-meta:
+        condition: service_healthy
+    environment:
+      HOSTNAME: 0.0.0.0
+      STUDIO_PG_META_URL: http://studio-meta:8080
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: ${POSTGRES_PORT:?Set POSTGRES_PORT}
+      POSTGRES_DB: ${POSTGRES_DB:?Set POSTGRES_DB}
+      POSTGRES_USER_READ_WRITE: flow_studio
+      POSTGRES_USER_READ_ONLY: flow_studio
+      DEFAULT_ORGANIZATION_NAME: UWFlow
+      DEFAULT_PROJECT_NAME: UWFlow database administration
+      PGRST_DB_SCHEMAS: public
+      # No Supabase API services are installed. Never supply UWFlow JWT keys.
+      SUPABASE_URL: http://127.0.0.1:9
+      SUPABASE_PUBLIC_URL: http://localhost:8001
+      NEXT_TELEMETRY_DISABLED: "1"
+      NEXT_PUBLIC_ENABLE_LOGS: "false"
+      ENABLED_FEATURES_LOGS_ALL: "false"
+      SNIPPETS_MANAGEMENT_FOLDER: /tmp/snippets
+    healthcheck:
+      test: [CMD, node, -e, "fetch('http://127.0.0.1:3000/api/platform/profile').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+
+  studio-meta:
+    image: supabase/postgres-meta:v0.96.6@sha256:a84cc713585eea7b401e4a2561ec4a1e48c87083d1c7ecb4502f204bb4391300
+    restart: unless-stopped
+    user: "1000:1000"
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    tmpfs:
+      - /tmp
+    env_file: ${STUDIO_ENV_FILE:-./admin/studio/.env}
+    entrypoint: [/bin/sh, /studio-entrypoint.sh]
+    command: [node, dist/server/server.js]
+    volumes:
+      - ./admin/studio/entrypoint.sh:/studio-entrypoint.sh:ro
+    networks: [studio-web, studio-db]
+    environment:
+      PG_META_PORT: "8080"
+      PG_META_DB_HOST: postgres
+      PG_META_DB_PORT: ${POSTGRES_PORT:?Set POSTGRES_PORT}
+      PG_META_DB_NAME: ${POSTGRES_DB:?Set POSTGRES_DB}
+      PG_META_DB_USER: flow_studio
+    healthcheck:
+      test: [CMD, node, -e, "fetch('http://127.0.0.1:8080/health').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+
+  studio-proxy:
+    image: nginx:1.30.4-alpine@sha256:dc5069ad14f19660b141b21236140b91656bf89bbc3e2417c70ae650cd66104c
+    restart: unless-stopped
+    user: "101:101"
+    entrypoint: [nginx, -g, "daemon off;"]
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: [no-new-privileges:true]
+    tmpfs:
+      - /tmp
+    networks: [studio-web, studio-ingress]
+    ports:
+      - "127.0.0.1:8001:8080"
+    depends_on:
+      studio:
+        condition: service_healthy
+    healthcheck:
+      test: [CMD-SHELL, "wget -S --spider --header='Host: localhost:8001' http://127.0.0.1:8080/ 2>&1 | grep -q '401 Unauthorized'"]
+      interval: 5s
+      timeout: 3s
+      retries: 6
+    volumes:
+      - ./admin/studio/nginx.conf:/etc/nginx/nginx.conf:ro
+      - type: bind
+        source: ./admin/studio/.secrets/htpasswd
+        target: /etc/nginx/studio.htpasswd
+        read_only: true
+        bind:
+          create_host_path: false
+
+networks:
+  # Only the gateway gets a routable network for the localhost port publication.
+  studio-ingress:
+  studio-web:
+    internal: true
+  studio-db:
+    internal: true


### PR DESCRIPTION
Adds an opt-in Supabase Studio admin interface for UWFlow's existing PostgreSQL 15 database. Administrators can browse tables and edit data through an SSH tunnel and password-protected gateway; application authentication and Hasura permissions/migrations keep their existing roles.

The Compose overlay runs pinned Studio, postgres-meta, and Nginx images. Only the gateway publishes a port (`127.0.0.1:8001`), and its authentication covers every Studio API route. Internal networks isolate Studio/meta from app containers, while Host/Origin checks reject cross-site requests. Admin secrets live in their own ignored environment file, with startup validation, rather than the shared application environment. Containers run without root or capabilities and use read-only root filesystems.

A dedicated `flow_studio` login grants database-wide data read/write access, including private schemas, without superuser, role creation, or RLS bypass. Treat it as privileged administration: Hasura permissions do not govern direct SQL. Schema changes remain in Hasura migrations. Supabase-specific Auth, Storage, Realtime, API, and monitoring panels are outside this deployment.

Validation:

- Passed `python3 admin/studio/test.py` against disposable stock PostgreSQL 15 using the actual overlay: dashboard/table discovery, SQL read/update/read, missing/wrong-password rejection, Host/Origin/cross-site rejection, RLS enforcement, and rejected superuser escalation/table deletion.
- Tested rejection of missing, malformed, and identical admin secrets; added the integration test to CircleCI.
- Validated merging with the real backend Compose file, shell syntax, ignored secret paths, and `git diff --check`.
- Terminal verification only; visual acceptance remains manual.

The runbook covers setup, backups, SSH access, credential rotation, upgrades, and removal. Initial activation recreates Postgres to attach the admin network and needs a brief maintenance window. Existing database storage and published backend ports are unchanged. This PR has not been deployed to production.
