### PR TITLE
Secure production Hasura CLI access through SSH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     depends_on:
       - postgres
     environment:
-      HASURA_GRAPHQL_ADMIN_SECRET: $HASURA_GRAPHQL_ADMIN_SECRET
+      HASURA_GRAPHQL_ADMIN_SECRET: ${HASURA_GRAPHQL_ADMIN_SECRET:?Set a non-empty Hasura admin secret}
       HASURA_GRAPHQL_DATABASE_URL: postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB
       HASURA_GRAPHQL_ENABLE_CONSOLE: "false" # Must be run manually to track migrations
       HASURA_GRAPHQL_ENABLE_TELEMETRY: "false" # Why is this even enabled by default?!
@@ -43,7 +43,9 @@ services:
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: $HASURA_GRAPHQL_UNAUTHORIZED_ROLE
     image: hasura/graphql-engine:v2.25.1.cli-migrations-v3
     ports:
-      - $HASURA_PORT:$HASURA_PORT
+      # Admin APIs are reachable from the host only; maintainers use SSH forwarding.
+      # Nginx continues to reach Hasura directly over the Docker network.
+      - 127.0.0.1:$HASURA_PORT:$HASURA_PORT
     restart: always
     volumes:
       - ./hasura/migrations:/hasura-migrations

--- a/hasura/README.md
+++ b/hasura/README.md
@@ -5,8 +5,8 @@ We use GraphQL to perform all CRUD operations for UWFlow.
 
 ## Interface
 
-Hasura listens on `HASURA_PORT` as specified in `.env`.
-It exposes a single endpoint expecting _only POSTs with JSON bodies_:
+Hasura's host port is bound to `127.0.0.1` on `HASURA_PORT` from `.env`.
+Its GraphQL endpoint accepts POSTs with JSON bodies:
 `http://HOST:HASURA_PORT/v1/graphql`.
 
 A sample JSON body posted to this endpoint might look like the following:
@@ -57,6 +57,73 @@ For example, with curl:
 $ curl -H 'x-hasura-admin-secret:secretinprod' http://localhost:8080/v1/graphql -d @payload
 ```
 will submit the contents of the file `payload` and get the response.
+
+## Production CLI and Console access
+
+Production administration uses an SSH tunnel to the host's loopback-bound Hasura
+port. The public `/graphql` route still uses Docker networking. The engine's
+built-in Console stays disabled; run the CLI Console on your own machine.
+SSH access and the production Hasura admin secret are both required. The admin
+secret grants full access, including through the public GraphQL endpoint; keep it
+in your password manager and never commit it or include it in command arguments.
+
+### Deployment prerequisite
+
+Deploy the updated `docker-compose.yml` and recreate Hasura using the normal
+deployment process. Ensure `HASURA_GRAPHQL_ADMIN_SECRET` is non-empty (Compose now
+rejects missing/empty values). `docker compose port hasura 8080` on the server
+should report `127.0.0.1:8080`, assuming the standard `HASURA_PORT=8080`.
+Keep the Hasura port blocked by the host/cloud firewall as well. Existing direct
+connections from other machines must switch to the tunnel; local development and
+Nginx's container-to-container connection still work.
+
+### Connect
+
+Install the Hasura v2 CLI and use a checkout matching the deployed migrations and
+metadata. Configure an SSH host alias with your production host, user, and key.
+Verify the server's SSH host-key fingerprint through a trusted channel and add it
+to `known_hosts` before using the helper; it refuses unknown or changed host keys.
+
+In one terminal, from the backend repository root, run:
+
+```sh
+bash script/hasura-prod-tunnel.sh YOUR_PROD_SSH_ALIAS
+```
+
+Leave it running. It binds only local `127.0.0.1:18080`, forwards to the server's
+`127.0.0.1:8080`, and exits if the local port cannot be bound. Optional second and
+third arguments override the local and remote ports. It uses a dedicated SSH
+connection so Ctrl-C closes this tunnel without affecting other SSH sessions.
+
+In a second terminal, start Bash and run the following from the repository root.
+The subshell drops the exported secret on exit; the hidden prompt keeps it out of
+shell history and command-line arguments. Do not enable shell tracing (`set -x`).
+
+```bash
+bash
+(
+  read -r -s -p 'Production Hasura admin secret: ' HASURA_GRAPHQL_ADMIN_SECRET || exit 1
+  printf '\n'
+  [[ -n $HASURA_GRAPHQL_ADMIN_SECRET ]] || exit 1
+  export HASURA_GRAPHQL_ADMIN_SECRET
+  export HASURA_GRAPHQL_ENDPOINT=http://127.0.0.1:18080
+  hasura --project hasura migrate status --database-name default &&
+    hasura --project hasura console --address 127.0.0.1 \
+      --api-host http://127.0.0.1 --no-browser
+)
+```
+
+Open `http://127.0.0.1:9695` yourself after the CLI starts. The Console and its
+migration API bind only to loopback. Console edits affect production immediately
+and can write migration/metadata files into this checkout; review and commit
+those changes. For CLI-only work, replace the `console` command above with the
+desired command, retaining the production endpoint and secret environment
+variables. Change the endpoint too if you override the tunnel's local port.
+
+Use Ctrl-C to stop the Console, then Ctrl-C in the first terminal to close the
+tunnel. Do not forward the Console or migration API ports to other machines.
+See the [Hasura CLI Console reference](https://hasura.io/docs/2.0/hasura-cli/commands/hasura_console/)
+for the supported flags and environment variables.
 
 ## Creating New Database Migrations
 

--- a/script/hasura-prod-tunnel.sh
+++ b/script/hasura-prod-tunnel.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 3 || $1 == -* ]]; then
+    echo "Usage: $0 SSH_HOST [LOCAL_PORT=18080] [REMOTE_HASURA_PORT=8080]" >&2
+    exit 2
+fi
+
+host=$1
+local_port=${2:-18080}
+remote_port=${3:-8080}
+for port in "$local_port" "$remote_port"; do
+    if [[ ! $port =~ ^[0-9]{1,5}$ ]] || (( 10#$port < 1 || 10#$port > 65535 )); then
+        echo "Ports must be integers between 1 and 65535." >&2
+        exit 2
+    fi
+done
+
+echo "Forwarding http://127.0.0.1:$local_port to Hasura on $host (Ctrl-C to close)."
+exec ssh -N -T \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -o ControlMaster=no \
+    -o ControlPath=none \
+    -o StrictHostKeyChecking=yes \
+    -L "127.0.0.1:$local_port:127.0.0.1:$remote_port" \
+    "$host"


### PR DESCRIPTION
Hasura currently publishes its port on all host interfaces. Bind it to `127.0.0.1` and provide an SSH tunnel helper so maintainers can run the production Hasura CLI and Console locally with SSH access plus the admin secret. The public GraphQL route continues to use Docker networking.

The helper uses loopback forwarding, strict host-key verification, port validation, keepalives, and a dedicated foreground connection. Compose rejects an empty admin secret. The runbook covers deployment, a hidden secret prompt, local Console bindings, migration tracking, and tunnel cleanup.

Validation: Bash syntax and `git diff --check` passed; rendered Compose configuration confirms the loopback binding and disabled built-in Console, and rejects an empty secret. Stubbed SSH checks passed for default/custom ports, seven invalid argument cases, security options, and error propagation. CLI flags were checked against the installed CLI and official documentation.

Live container/tunnel testing was not performed because the local Docker daemon is stopped. Production was not modified. Deployment requires recreating Hasura with the updated Compose file; existing remote connections to its host port must switch to SSH forwarding.
