### PR TITLE
Launch production Hasura Console on a specified local port

### DIFF
--- a/hasura/README.md
+++ b/hasura/README.md
@@ -84,44 +84,33 @@ metadata. Configure an SSH host alias with your production host, user, and key.
 Verify the server's SSH host-key fingerprint through a trusted channel and add it
 to `known_hosts` before using the helper; it refuses unknown or changed host keys.
 
-In one terminal, from the backend repository root, run:
+From the backend repository root, run one command. The optional second argument
+is the local port where you want to open the **Console**, defaulting to `9695`:
 
 ```sh
-bash script/hasura-prod-tunnel.sh YOUR_PROD_SSH_ALIAS
+./script/hasura-prod-tunnel.sh uwflow-prod 9695
 ```
 
-Leave it running. It binds only local `127.0.0.1:18080`, forwards to the server's
-`127.0.0.1:8080`, and exits if the local port cannot be bound. Optional second and
-third arguments override the local and remote ports. It uses a dedicated SSH
-connection so Ctrl-C closes this tunnel without affecting other SSH sessions.
+Replace `uwflow-prod` with your SSH alias if different. Enter the production
+Hasura admin secret at the hidden prompt, then open `http://127.0.0.1:9695` once
+the CLI reports it is ready. No second terminal or separate CLI command is needed.
+The script can also be invoked from another working directory.
 
-In a second terminal, start Bash and run the following from the repository root.
-The subshell drops the exported secret on exit; the hidden prompt keeps it out of
-shell history and command-line arguments. Do not enable shell tracing (`set -x`).
+The script forwards the server's Hasura API on port `8080` through SSH and runs
+the Hasura CLI Console locally. It uses the next two local ports internally:
+for Console port `9695`, the migration API uses `9696` and the engine tunnel uses
+`9697`. All three bind to `127.0.0.1`. Choose another Console port if any of these
+ports are occupied; the allowed range is `1024`–`65533`. The remote Hasura port is
+fixed at the production default, `8080`.
 
-```bash
-bash
-(
-  read -r -s -p 'Production Hasura admin secret: ' HASURA_GRAPHQL_ADMIN_SECRET || exit 1
-  printf '\n'
-  [[ -n $HASURA_GRAPHQL_ADMIN_SECRET ]] || exit 1
-  export HASURA_GRAPHQL_ADMIN_SECRET
-  export HASURA_GRAPHQL_ENDPOINT=http://127.0.0.1:18080
-  hasura --project hasura migrate status --database-name default &&
-    hasura --project hasura console --address 127.0.0.1 \
-      --api-host http://127.0.0.1 --no-browser
-)
-```
+The secret is supplied to the CLI through its environment, without putting it in
+command arguments or writing it to disk. Console edits affect production
+immediately and can write migration/metadata files into this checkout; review
+and commit those changes.
 
-Open `http://127.0.0.1:9695` yourself after the CLI starts. The Console and its
-migration API bind only to loopback. Console edits affect production immediately
-and can write migration/metadata files into this checkout; review and commit
-those changes. For CLI-only work, replace the `console` command above with the
-desired command, retaining the production endpoint and secret environment
-variables. Change the endpoint too if you override the tunnel's local port.
-
-Use Ctrl-C to stop the Console, then Ctrl-C in the first terminal to close the
-tunnel. Do not forward the Console or migration API ports to other machines.
+Leave the command running while using the Console. Ctrl-C stops the Console and
+closes its dedicated SSH tunnel. Startup failures also close the tunnel. Do not
+forward these local ports to other machines.
 See the [Hasura CLI Console reference](https://hasura.io/docs/2.0/hasura-cli/commands/hasura_console/)
 for the supported flags and environment variables.
 

--- a/script/hasura-prod-tunnel.sh
+++ b/script/hasura-prod-tunnel.sh
@@ -1,28 +1,77 @@
 #!/usr/bin/env bash
+# Keep the secret out of traces, even when invoked with bash -x.
+set +x
 set -euo pipefail
 
-if [[ $# -lt 1 || $# -gt 3 || $1 == -* ]]; then
-    echo "Usage: $0 SSH_HOST [LOCAL_PORT=18080] [REMOTE_HASURA_PORT=8080]" >&2
+if [[ $# -lt 1 || $# -gt 2 || $1 == -* ]]; then
+    echo "Usage: $0 SSH_HOST [CONSOLE_PORT=9695]" >&2
     exit 2
 fi
-
 host=$1
-local_port=${2:-18080}
-remote_port=${3:-8080}
-for port in "$local_port" "$remote_port"; do
-    if [[ ! $port =~ ^[0-9]{1,5}$ ]] || (( 10#$port < 1 || 10#$port > 65535 )); then
-        echo "Ports must be integers between 1 and 65535." >&2
-        exit 2
+console_port=${2:-9695}
+if [[ ! $console_port =~ ^[0-9]{1,5}$ ]] || (( 10#$console_port < 1024 || 10#$console_port > 65533 )); then
+    echo "Console port must be an integer between 1024 and 65533." >&2
+    exit 2
+fi
+console_port=$((10#$console_port))
+# Reserve adjacent loopback ports for the CLI migration API and engine tunnel.
+api_port=$((console_port + 1))
+engine_port=$((console_port + 2))
+project_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../hasura" && pwd)"
+for dependency in ssh hasura curl; do
+    if ! command -v "$dependency" >/dev/null 2>&1; then
+        echo "Required command not found: $dependency" >&2
+        exit 1
     fi
 done
 
-echo "Forwarding http://127.0.0.1:$local_port to Hasura on $host (Ctrl-C to close)."
-exec ssh -N -T \
+# Always prompt for production credentials; do not silently use a local .env.
+read -r -s -p 'Production Hasura admin secret: ' admin_secret || exit 1
+printf '\n'
+if [[ -z $admin_secret ]]; then
+    echo "The production admin secret cannot be empty." >&2
+    exit 1
+fi
+
+# A private control socket lets cleanup close only this script's SSH connection.
+tunnel_dir=$(mktemp -d "${TMPDIR:-/tmp}/uwflow-hasura.XXXXXX")
+console_pid=
+cleanup() {
+    if [[ -n $console_pid ]]; then
+        kill "$console_pid" 2>/dev/null || true
+        wait "$console_pid" 2>/dev/null || true
+    fi
+    ssh -S "$tunnel_dir/socket" -O exit "$host" >/dev/null 2>&1 || true
+    rm -rf "$tunnel_dir"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+ssh -M -S "$tunnel_dir/socket" -f -N -T \
     -o ExitOnForwardFailure=yes \
     -o ServerAliveInterval=30 \
     -o ServerAliveCountMax=3 \
-    -o ControlMaster=no \
-    -o ControlPath=none \
+    -o ControlPersist=no \
     -o StrictHostKeyChecking=yes \
-    -L "127.0.0.1:$local_port:127.0.0.1:$remote_port" \
+    -L "127.0.0.1:$engine_port:127.0.0.1:8080" \
     "$host"
+
+# -f returns after SSH establishes the forward. Check the remote engine too.
+if ! curl --noproxy '*' --fail --silent --show-error --max-time 10 \
+    "http://127.0.0.1:$engine_port/healthz" >/dev/null; then
+    echo "Cannot reach production Hasura on the server's port 8080." >&2
+    exit 1
+fi
+
+echo "Starting production Hasura Console at http://127.0.0.1:$console_port"
+echo "Console edits affect production immediately. Ctrl-C closes the Console and tunnel."
+HASURA_GRAPHQL_ADMIN_SECRET="$admin_secret" hasura --project "$project_dir" console \
+    --endpoint "http://127.0.0.1:$engine_port" \
+    --console-hge-endpoint "http://127.0.0.1:$engine_port" \
+    --address 127.0.0.1 \
+    --console-port "$console_port" \
+    --api-host http://127.0.0.1 \
+    --api-port "$api_port" \
+    --no-browser &
+console_pid=$!
+wait "$console_pid"


### PR DESCRIPTION
The SSH helper previously forwarded only the Hasura API, leaving maintainers to start the Console in another terminal. It now accepts `SSH_HOST [CONSOLE_PORT=9695]`, prompts for the production admin secret, opens the tunnel, and launches the actual Hasura CLI Console on the requested loopback port.

For example, `./script/hasura-prod-tunnel.sh uwflow-prod 9695` serves the Console at `http://127.0.0.1:9695`. The next two local ports are used internally for the migration API and engine tunnel. Production Hasura remains on port 8080. Ctrl-C and startup failures clean up the dedicated SSH connection. The helper is executable and works from any working directory; the runbook now documents the single-command workflow.

Validation: Bash syntax and `git diff --check` passed. Stubbed process checks covered invalid ports, default/custom Console ports, secret handling, working-directory independence, SSH/engine/CLI failures, and termination cleanup. CLI flags were checked against the installed Hasura CLI. No production connection or visual Console test was performed.

Follow-up to merged PR #219.
