### PR TITLE
Add admin-approved Neon previews on EC2 with automatic cleanup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -32,3 +32,7 @@ SMTP_PORT=587
 SMTP_FROM=info@uwflow.com
 SMTP_USERNAME=test
 SMTP_PASSWORD=test
+
+# Optional full Postgres connection URI (e.g. Neon TLS); overrides POSTGRES_* in Go.
+# Leave empty for existing local/production configuration.
+DATABASE_URL=

--- a/.github/workflows/preview-checks.yml
+++ b/.github/workflows/preview-checks.yml
@@ -1,0 +1,21 @@
+name: Preview control plane checks
+on:
+  pull_request:
+    paths: ['preview/**', 'flow/**', '.github/workflows/preview*.yml']
+  push:
+    branches: [main]
+    paths: ['preview/**', 'flow/**', '.github/workflows/preview*.yml']
+permissions:
+  contents: read
+jobs:
+  controller:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: docker run --rm -v "$PWD:/repo:ro" -w /repo rhysd/actionlint:1.7.7 .github/workflows/preview.yml .github/workflows/preview-checks.yml
+      - run: python3 -m unittest discover -s preview/tests -v
+      - run: docker build --target api -t uwflow-preview-api-validation flow
+      - run: docker build -f preview/Hasura.Dockerfile -t uwflow-preview-hasura-validation .
+      - run: python3 preview/smoke.py

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,127 @@
+name: Approved branch preview
+run-name: "Preview ${{ inputs.action }} · frontend PR #${{ inputs.pr }}"
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        type: choice
+        options: [deploy, destroy, status]
+        default: deploy
+      pr:
+        description: Frontend PR number (ignored for status)
+        required: true
+        type: string
+      backend_sha:
+        description: Optional full backend SHA; defaults to main at request time
+        type: string
+      ttl_hours:
+        description: Lifetime in hours (host maximum is authoritative)
+        type: choice
+        options: ['1', '4', '8', '24']
+        default: '24'
+permissions:
+  contents: read
+concurrency:
+  group: approved-preview-${{ inputs.pr }}
+  cancel-in-progress: false
+jobs:
+  resolve:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      frontend_sha: ${{ steps.resolve.outputs.frontend_sha }}
+      backend_sha: ${{ steps.resolve.outputs.backend_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_ACTION: ${{ inputs.action }}
+          PREVIEW_PR: ${{ inputs.pr }}
+          PREVIEW_BACKEND_SHA: ${{ inputs.backend_sha }}
+        run: python3 preview/resolve.py
+  deploy:
+    needs: resolve
+    name: Approve ${{ inputs.action }} · frontend ${{ needs.resolve.outputs.frontend_sha }} · backend ${{ needs.resolve.outputs.backend_sha }}
+    environment: ec2-preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          path: control
+      - uses: actions/checkout@v4
+        if: inputs.action == 'deploy'
+        with:
+          ref: ${{ needs.resolve.outputs.backend_sha }}
+          persist-credentials: false
+          path: source
+      # PR code is compiled on this ephemeral runner, never on EC2. Dockerfiles
+      # come from the approved control plane on main, not the requested SHA.
+      - name: Build approved backend
+        if: inputs.action == 'deploy'
+        run: |
+          docker build --target api -f control/flow/Dockerfile -t preview-api source/flow
+          docker build -f control/preview/Hasura.Dockerfile -t preview-hasura source
+      - name: Publish immutable images
+        id: images
+        if: inputs.action == 'deploy'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GH_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+          trap 'docker logout ghcr.io' EXIT
+          prefix="ghcr.io/${GITHUB_REPOSITORY,,}-preview"
+          for service in api hasura; do
+            image="$prefix-$service:$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+            docker tag "preview-$service" "$image"
+            docker push "$image"
+            digest=$(docker inspect --format '{{index .RepoDigests 0}}' "$image")
+            printf '%s_image=%s\n' "$service" "$digest" >> "$GITHUB_OUTPUT"
+          done
+      - name: Request deployment through restricted SSH command
+        env:
+          PREVIEW_ACTION: ${{ inputs.action }}
+          PREVIEW_PR: ${{ inputs.pr }}
+          FRONTEND_SHA: ${{ needs.resolve.outputs.frontend_sha }}
+          BACKEND_SHA: ${{ needs.resolve.outputs.backend_sha }}
+          API_IMAGE: ${{ steps.images.outputs.api_image }}
+          HASURA_IMAGE: ${{ steps.images.outputs.hasura_image }}
+          TTL_HOURS: ${{ inputs.ttl_hours }}
+          EC2_HOST: ${{ vars.PREVIEW_EC2_HOST }}
+          SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.PREVIEW_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          umask 077
+          mkdir -p "$HOME/.ssh"
+          printf '%s\n' "$SSH_KEY" > "$HOME/.ssh/preview"
+          printf '%s\n' "$KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          trap 'rm -f "$HOME/.ssh/preview"' EXIT
+          python3 control/preview/request.py > request.json
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -o ServerAliveInterval=30 \
+            -i "$HOME/.ssh/preview" "preview-deploy@$EC2_HOST" < request.json > preview-result.json
+          cat preview-result.json
+          python3 - <<'PY'
+          import json, os, datetime
+          records = json.load(open('preview-result.json'))
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as out:
+              for record in records:
+                  expiry = datetime.datetime.fromtimestamp(record['expires_at'], datetime.timezone.utc).isoformat()
+                  out.write(f"\n**{record['key']}** ({record['phase']}): {record['url']}\n\n")
+                  out.write(f"Frontend `{record['frontend_sha']}` · backend `{record['backend_sha']}` · expires {expiry}\n")
+          PY
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: preview-result-${{ github.run_id }}
+          path: preview-result.json
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ terraform.tfvars
 # TLS certs/keys — never commit
 *.pem
 
+
+# Preview controller Python caches
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -127,3 +127,7 @@ $ docker exec -it postgres sh
 
 There are other `make` commands available, use `make help` to explore them, or simply visit `Makefile`
 
+
+## Branch previews
+
+See [admin-approved Neon previews on EC2](preview/README.md) for isolated per-PR databases, Vercel review URLs, capacity limits, automatic cleanup, and setup instructions.

--- a/flow/Dockerfile
+++ b/flow/Dockerfile
@@ -47,7 +47,7 @@ CMD ["air"]
 FROM alpine:latest AS api
 
 # parsing and webcal pull in these runtime dependencies
-RUN apk add --no-cache poppler && \
+RUN apk add --no-cache ca-certificates poppler && \
     ln -s /usr/lib/libpoppler-cpp.so.2 /usr/lib/libpoppler-cpp.so.0
 
 COPY --from=builder /build/api/api /app/api

--- a/flow/common/db/pool.go
+++ b/flow/common/db/pool.go
@@ -15,11 +15,14 @@ const ConnectTimeout = time.Second * 10
 
 // Connect to database.
 func ConnectPool(ctx context.Context, env *env.Environment) (*Conn, error) {
-	uri := fmt.Sprintf(
-		"postgres://%s:%s@%s:%s/%s?sslmode=disable",
-		env.PostgresUser, env.PostgresPassword,
-		env.PostgresHost, env.PostgresPort, env.PostgresDatabase,
-	)
+	uri := env.DatabaseURL
+	if uri == "" {
+		uri = fmt.Sprintf(
+			"postgres://%s:%s@%s:%s/%s?sslmode=disable",
+			env.PostgresUser, env.PostgresPassword,
+			env.PostgresHost, env.PostgresPort, env.PostgresDatabase,
+		)
+	}
 	connectCtx, cancel := context.WithTimeout(ctx, ConnectTimeout)
 	defer cancel()
 

--- a/flow/common/db/pool_test.go
+++ b/flow/common/db/pool_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"context"
+	"flow/common/env"
+	"testing"
+)
+
+func TestDatabaseURLPreservesTLSAndPoolLimit(t *testing.T) {
+	conn, err := ConnectPool(context.Background(), &env.Environment{
+		DatabaseURL:  "postgres://preview:password@ep-example.neon.tech/flow?sslmode=verify-full&pool_max_conns=5",
+		PostgresHost: "legacy-host-must-not-be-used",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.pool.Close()
+	config := conn.pool.Config()
+	if config.MaxConns != 5 || config.ConnConfig.Host != "ep-example.neon.tech" {
+		t.Fatal("DATABASE_URL must override legacy configuration and preserve the connection limit")
+	}
+	if config.ConnConfig.TLSConfig == nil || config.ConnConfig.TLSConfig.InsecureSkipVerify {
+		t.Fatal("Neon connection must verify TLS")
+	}
+}
+
+func TestLegacyDatabaseConfiguration(t *testing.T) {
+	conn, err := ConnectPool(context.Background(), &env.Environment{
+		PostgresUser: "flow", PostgresPassword: "local", PostgresHost: "localhost",
+		PostgresPort: "5432", PostgresDatabase: "flow",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.pool.Close()
+	if conn.pool.Config().ConnConfig.Host != "localhost" {
+		t.Fatal("legacy configuration changed")
+	}
+}

--- a/flow/common/env/env.go
+++ b/flow/common/env/env.go
@@ -14,15 +14,17 @@ type Environment struct {
 
 	JwtKey []byte `from:"HASURA_GRAPHQL_JWT_KEY"`
 
+	DatabaseURL string `from:"DATABASE_URL" optional:"true"`
+
 	PostgresDatabase string `from:"POSTGRES_DB"`
 	PostgresHost     string `from:"POSTGRES_HOST"`
 	PostgresPassword string `from:"POSTGRES_PASSWORD"`
 	PostgresPort     string `from:"POSTGRES_PORT"`
 	PostgresUser     string `from:"POSTGRES_USER"`
 
-	RunMode		string `from:"RUN_MODE"`
+	RunMode string `from:"RUN_MODE"`
 
-	UWApiKeyv3	string `from:"UW_API_KEY_V3"`
+	UWApiKeyv3 string `from:"UW_API_KEY_V3"`
 }
 
 // To avoid mind-numbing boilerplate, use reflection.
@@ -41,7 +43,7 @@ func Get(env interface{}) error {
 			fieldType := envType.Field(i).Type
 			convertedValue := reflect.ValueOf(value).Convert(fieldType)
 			envReflect.Field(i).Set(convertedValue)
-		} else {
+		} else if envType.Field(i).Tag.Get("optional") != "true" {
 			return fmt.Errorf("environment variable %s is not set", envKey)
 		}
 	}

--- a/flow/common/env/env_test.go
+++ b/flow/common/env/env_test.go
@@ -1,0 +1,28 @@
+package env
+
+import "testing"
+
+func TestOptionalEnvironment(t *testing.T) {
+	t.Setenv("ENV_TEST_REQUIRED", "present")
+	type config struct {
+		Required string `from:"ENV_TEST_REQUIRED"`
+		Optional string `from:"ENV_TEST_OPTIONAL" optional:"true"`
+	}
+	var value config
+	if err := Get(&value); err != nil || value.Required != "present" || value.Optional != "" {
+		t.Fatalf("optional field should not break existing deployments: %+v, %v", value, err)
+	}
+	t.Setenv("ENV_TEST_OPTIONAL", "postgres://example/db?sslmode=verify-full")
+	if err := Get(&value); err != nil || value.Optional == "" {
+		t.Fatalf("optional field should be loaded when present: %v", err)
+	}
+}
+
+func TestRequiredEnvironmentStillFails(t *testing.T) {
+	var value struct {
+		Missing string `from:"ENV_TEST_UNSET"`
+	}
+	if err := Get(&value); err == nil {
+		t.Fatal("missing required configuration must fail")
+	}
+}

--- a/preview/Hasura.Dockerfile
+++ b/preview/Hasura.Dockerfile
@@ -1,0 +1,5 @@
+FROM hasura/graphql-engine:v2.25.1.cli-migrations-v3
+COPY hasura/migrations /hasura-migrations
+COPY hasura/metadata /hasura-metadata
+# Metadata overrides the engine's default pool limit. Keep each preview small.
+RUN sed -i 's/max_connections: 250/max_connections: 10/' /hasura-metadata/databases/databases.yaml

--- a/preview/README.md
+++ b/preview/README.md
@@ -1,0 +1,173 @@
+# Admin-approved Neon previews on EC2
+
+A maintainer requests a frontend PR preview in GitHub Actions. An administrator approves the exact frontend and backend commits in the `ec2-preview` environment. The workflow builds the backend on a GitHub runner, then EC2 reserves a slot, creates a Neon child branch, starts API/Hasura/gateway containers, and creates a Vercel deployment. The workflow summary contains the review URL, both SHAs, and expiry.
+
+A new commit does **not** execute on EC2 until another request is approved. Backend code defaults to the backend main SHA resolved before approval; supply another full backend SHA to test a coordinated change. This first version supports frontend PRs in `UWFlow/uwflow_frontend`; fork PRs must first be copied to a maintainer-owned branch for review.
+
+```text
+GitHub request -> exact-SHA approval -> build images on GitHub
+                                         |
+                                         v
+                         EC2 capacity lock + durable journal
+                              /                      \
+                 Neon child branch             API + Hasura
+                                                     ^
+Vercel review URL -> same-origin /api and /graphql -> gateway
+```
+
+## What is enforced
+
+- **Capacity:** one active/provisioning/deleting preview by default. The host also requires 1.5 GiB available RAM and 4 GiB free Docker disk before deployment. Adjust only after measuring production headroom. A small existing instance may refuse deployment until resized.
+- **Limits:** API 256 MiB, Hasura 768 MiB, gateway 64 MiB; each has a 0.5 CPU and 128 PID limit and bounded logs. The API uses five database connections; Hasura metadata uses ten. Neon compute is fixed at 0.25 CU with five-minute auto-suspend configured. Hasura activity can prevent suspension, so do not assume previews cost nothing.
+- **Lifetime:** 24 hours by default, configurable down to one hour; the host maximum is authoritative. A successful redeployment of an approved PR preserves its database/JWT and renews its lifetime. Updates briefly stop that preview; a failed update destroys the preview and its database so the next request starts clean. There is no hourly reset. Destroy then deploy to start again from the baseline.
+- **Cleanup:** the EC2 systemd timer checks every five minutes for closed/merged PRs, expired leases, and failed attempts. It removes containers and private networks first, then the Neon branch, owned Vercel deployments, credentials and unused preview images. It never runs global Docker prune or touches production volumes. The shared edge network remains installed. Published GHCR build images remain in the registry as build artifacts; configure package retention separately if needed.
+- **Recovery:** reservations and unique ownership names are journaled before cloud creation. Cleanup discovers resources even if a create response was lost. Cloud failures retain the slot and journal for retry; local compute is stopped on expiry even if GitHub/Neon/Vercel are unavailable. Keep `/var/lib/uwflow-preview` on persistent EC2 storage.
+- **Bounded operations:** a host operation has a 25-minute hard deadline. Operations serialize using `flock`; a running deployment can delay the timer by up to that bound. A killed provisioning attempt expires after 30 minutes. Normal ready-preview cleanup runs on the next five-minute timer tick; it does not rely on GitHub scheduled workflows/webhooks.
+
+Containers share the production kernel. The limits reduce accidental overload; they do not sandbox hostile code from production. Approve only reviewed backend code, keep production credentials/mounts and the Docker socket out of previews, and block container access to EC2 instance metadata. Use separate compute if arbitrary fork code must run.
+
+## 1. Create and seed Neon
+
+1. Create a **separate preview project**, near EC2, with Postgres 15. Do not branch from production data. Rename its root branch `baseline`.
+2. Create a `flow_preview` role and database owned by that role. This dedicated project should contain only synthetic data and this preview application role; no production roles or passwords. Record the project ID, baseline branch ID, database and role names.
+3. From a trusted checkout of this backend with these changes, install Docker Compose v2 and run:
+
+   ```sh
+   python3 preview/bootstrap.py
+   ```
+
+   Paste the baseline database's **direct**, unpooled Neon connection URI at the hidden prompt. The helper requires database name `flow_preview`, verifies TLS, applies the repository's Hasura migrations/metadata, inserts `preview/seed.sql`, and removes its temporary local container. The Neon baseline remains. This writes to the selected baseline database; run it only against the new preview project.
+4. Record the backend commit used to initialize the baseline. Deploy newer revisions with forward-compatible migrations. Do not deploy older schema revisions against a newer baseline. To change/reset the baseline, first destroy active previews, update the baseline using a trusted revision, then create new previews.
+5. Create a Neon API token scoped to this preview project where available. Put it in the root-only EC2 config below. The controller resets the child role password before starting any PR containers, so they never receive the baseline password.
+
+Neon supplies Postgres branching here. Existing UWFlow email/JWT authentication remains in use; this does not migrate to Neon Auth or repair Google OAuth origin restrictions.
+
+## 2. Prepare a Vercel project
+
+Create a **dedicated** `uwflow-preview` Vercel project, with no production environment variables, Sentry upload token, production aliases or production domains. Use Bun 1.3.14 / the repository's pinned package manager. Disable automatic Git deployments for this dedicated project: the controller uploads the approved SHA's source through the Vercel API. Record its project ID, team ID and a token with access to it.
+
+The uploaded copy receives a generated `vercel.json` that overrides production rewrites, runs `build:vercel`, and routes `/api` and `/graphql` to `https://pr-N.preview-api.uwflow.com`. The browser uses same-origin URLs, avoiding preview CORS configuration. No database/admin/cloud secret goes into the browser or Vercel build. Repository files are not modified.
+
+Existing automatic Vercel previews are separate; they are **not** silently redirected. Use the URL from the approved workflow summary for the isolated preview. On expiry that deployment is deleted, and its backend becomes unavailable; there is no production fallback.
+
+## 3. Install the EC2 controller
+
+Use Ubuntu with Python 3.10+, Docker and the **`docker compose` plugin**. Older EC2 setup scripts installed only `/usr/local/bin/docker-compose`; install the plugin if `docker compose version` fails. Images are built on GitHub's Linux x86_64 runner, so use an x86_64 EC2 instance.
+
+From a trusted checkout on EC2:
+
+```sh
+sudo install -d -m 755 /opt/uwflow-preview
+sudo install -d -m 700 /etc/uwflow-preview /var/lib/uwflow-preview
+sudo install -m 644 preview/controller.py /opt/uwflow-preview/controller.py
+sudo install -m 755 preview/ssh-command /opt/uwflow-preview/ssh-command
+sudo install -m 600 preview/config.example.json /etc/uwflow-preview/config.json
+sudoedit /etc/uwflow-preview/config.json
+sudo docker network create uwflow-preview-edge
+```
+
+Fill every `REPLACE` field. `github_token` needs read access to the public frontend PR API; it needs no write permissions. Neon and Vercel tokens stay on EC2. Restrict token scope to the separate preview projects as far as the providers allow. The example image prefix must match the backend repository's GHCR packages (`ghcr.io/uwflow/uwflow-preview-api` and `...-hasura`).
+
+GHCR packages initially default to private. Either give root's Docker client read access using a dedicated `read:packages` token (`sudo docker login ghcr.io`), or make just these preview packages public after their first publication. If you choose public packages, the first deployment may fail to pull before you change package visibility; cleanup removes that attempt and a new approved run can proceed. The timer does not need image registry credentials to stop containers.
+
+Require IMDSv2 and set EC2's metadata response hop limit to 1. Verify from a disposable container that instance metadata cannot be reached, and restrict the instance's IAM role to what production actually needs. Do not expose Docker's API over TCP. Restrict inbound traffic to the existing HTTPS proxy and authenticated SSH; the controller publishes diagnostic ports only on loopback.
+
+## 4. Configure restricted deployment SSH
+
+Create a separate Linux account; **do not** add it to the Docker group:
+
+```sh
+sudo useradd --create-home --shell /bin/sh preview-deploy
+sudo install -d -o root -g root -m 755 /home/preview-deploy/.ssh
+sudo touch /home/preview-deploy/.ssh/authorized_keys
+sudo chown root:root /home/preview-deploy /home/preview-deploy/.ssh/authorized_keys
+sudo chmod 755 /home/preview-deploy
+sudo chmod 644 /home/preview-deploy/.ssh/authorized_keys
+sudo visudo -f /etc/sudoers.d/uwflow-preview
+```
+
+Add exactly this sudoers rule:
+
+```text
+preview-deploy ALL=(root) NOPASSWD: /usr/bin/python3 /opt/uwflow-preview/controller.py request
+```
+
+Generate a dedicated deployment SSH key on your workstation. Add its public key to `authorized_keys` as one line:
+
+```text
+restrict,command="/opt/uwflow-preview/ssh-command" ssh-ed25519 YOUR_PUBLIC_KEY
+```
+
+Keep the account home, key file, controller and config root-owned. `restrict` disables forwarding/PTY; the forced command ignores `SSH_ORIGINAL_COMMAND` and accepts bounded JSON only. Do not reuse your normal administrator SSH key.
+
+Verify the EC2 host-key fingerprint through your existing trusted admin session. Save that verified known_hosts entry; the workflow rejects unknown/changed host keys rather than using `ssh-keyscan` as trust-on-first-use.
+
+## 5. Route HTTPS to preview gateways
+
+1. Point `*.preview-api.uwflow.com` at EC2. Obtain a publicly trusted wildcard certificate using DNS validation and configure renewal. The existing production certificate usually will not cover these names.
+2. Place the wildcard certificate and key in the production checkout's `.ssl/preview/fullchain.pem` and `.ssl/preview/privkey.pem`.
+3. Copy `preview/edge.conf.example` to the production checkout's `nginx/config/preview.conf`, adjusting its domain. It resolves a PR-specific gateway through Docker DNS and never routes a missing preview to production.
+4. Attach the existing `frontend` reverse proxy to the shared network persistently using the supplied Compose override:
+
+   ```sh
+   docker compose -f docker-compose.yml -f preview/production-edge.override.yml config --quiet
+   docker compose -f docker-compose.yml -f preview/production-edge.override.yml up -d --no-deps frontend
+   docker exec frontend nginx -t
+   ```
+
+   This recreates only the existing proxy and briefly interrupts frontend connections; arrange the one-time change accordingly. Keep the override in the production proxy's future startup commands. Existing production deploys that touch only API/Hasura/importer/email do not need it. The existing `/nginx/run.sh` generates the preview server config on startup. Do not start a second listener on ports 80/443.
+
+Validate DNS and certificate issuance before the first preview. From outside EC2, an undeployed `pr-N` host should return a gateway error, never production app data.
+
+## 6. Enable cleanup before allowing deployment
+
+```sh
+sudo install -m 644 preview/uwflow-preview-gc.service preview/uwflow-preview-gc.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now uwflow-preview-gc.timer
+sudo systemctl start uwflow-preview-gc.service
+sudo systemctl list-timers uwflow-preview-gc.timer
+sudo journalctl -u uwflow-preview-gc.service -n 30
+```
+
+Monitor timer failures. The timer starts after reboot and does not require a CI secret. Do not delete the state directory to fix a stuck slot: retry reconciliation after restoring provider access. Failed partial provisioning is deliberately counted toward capacity until cleanup is complete.
+
+## 7. Configure the GitHub admin gate
+
+After merging this draft PR, in **UWFlow/uwflow → Settings → Environments**, create `ec2-preview`:
+
+- Add designated administrators as **required reviewers**. Enable **Prevent self-review** if a second administrator should approve requests; otherwise a designated administrator may approve their own request.
+- Disable administrator bypass of protection rules. Restrict deployment branches to **main only**.
+- Add environment secret `PREVIEW_SSH_KEY` (the dedicated private key) and `PREVIEW_KNOWN_HOSTS` (the verified host entry).
+- Add environment variable `PREVIEW_EC2_HOST` (EC2 hostname).
+
+Do this **before** adding the SSH secret. Without required reviewers, naming an environment alone does not create an approval gate. The workflow runs from `main` only, resolves SHAs in a read-only job, then blocks at the protected environment before building/deploying. Do not place the deployment key in repository-level secrets or authorize PR branch workflows to use it.
+
+Required environment reviewers are available for public repositories on GitHub Free; this backend repository is public. If repository visibility changes, verify your plan still supports required reviewers. Protect changes to `.github/workflows/preview.yml`, `preview/` and `flow/Dockerfile` through your normal main-branch review rules.
+
+Open **Actions → Approved branch preview → Run workflow**, choose `main`, `deploy`, the frontend PR number, optional full backend SHA and TTL. Review the exact SHAs shown, approve, then use the URL in the workflow summary. Run again with `destroy` to remove immediately or `status` to list leases. A PR closed during deployment is rejected/cleaned; one that changes while approval is pending requires a new request.
+
+## Review and validation
+
+Run these locally without cloud credentials:
+
+```sh
+python3 -m unittest discover -s preview/tests -v
+docker build --target api -t uwflow-preview-api-validation flow
+docker build -f preview/Hasura.Dockerfile -t uwflow-preview-hasura-validation .
+python3 preview/smoke.py
+```
+
+The same checks run on PRs in `preview-checks.yml`. The smoke test creates isolated containers with ephemeral Postgres, applies real migrations, checks signup/login and review creation/editing through the gateway, deletes its test account, then removes its stack. It uses HTTP APIs, not a browser, and does not contact Neon/Vercel or production.
+
+After one-time provider setup, validate the real path with a **one-hour** approved preview:
+
+1. Open the workflow URL. Create an account, sign out/in, post a CS135 review, and edit it. The baseline has a synthetic CS135 course; import a sanitized catalog into the baseline if richer manual testing is needed.
+2. Check the browser's network requests use that URL's `/api` and `/graphql`, whose Vercel rewrites point to the PR backend. Confirm the matching Neon child exists.
+3. Attempt a second preview with capacity one; it must be refused. Push another frontend commit; no new EC2 deployment should occur automatically.
+4. Close the PR and confirm the timer removes containers, Neon child and Vercel deployment. Repeat with TTL expiry while GitHub access is temporarily unavailable; EC2 containers must still stop.
+5. Check production health throughout. Only raise capacity after measuring peak memory, CPU and disk usage under review traffic.
+
+This provides the isolated hosted target for manual validation and future hosted Playwright runs. The frontend's existing E2E helper currently accepts only local endpoints; this PR does not change that runner or enable Google SSO on arbitrary preview origins. Email/password works against the real API. Browser E2E and Google OAuth migration should be validated separately against this infrastructure.
+
+Provider contracts: [GitHub environment protection](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments), [Neon branch creation](https://api-docs.neon.tech/reference/createprojectbranch), [child role password reset](https://api-docs.neon.tech/reference/resetprojectbranchrolepassword), [Vercel source deployments](https://vercel.com/docs/rest-api/deployments/create-a-new-deployment).

--- a/preview/bootstrap.py
+++ b/preview/bootstrap.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Initialize a separately created Neon baseline; run locally, never in PR jobs."""
+import getpass
+import json
+from pathlib import Path
+import secrets
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.parse
+
+from controller import api, write_json
+
+HERE = Path(__file__).resolve().parent
+
+
+def main():
+    uri = getpass.getpass('Direct Neon URI for the NEW flow_preview database: ')
+    parsed = urllib.parse.urlsplit(uri)
+    if parsed.scheme not in ('postgres', 'postgresql') or not (parsed.hostname or '').endswith('.neon.tech') or parsed.path != '/flow_preview':
+        raise ValueError('Use a direct Neon connection to the separate flow_preview database')
+    if '-pooler' in parsed.hostname:
+        raise ValueError('Use the direct/unpooled connection')
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    params.update(sslmode='verify-full', sslrootcert='/etc/ssl/certs/ca-certificates.crt')
+    uri = urllib.parse.urlunsplit(parsed._replace(query=urllib.parse.urlencode(params)))
+    subprocess.run(['docker', 'build', '-f', str(HERE / 'Hasura.Dockerfile'), '-t', 'uwflow-preview-baseline', str(HERE.parent)], check=True)
+    with socket.socket() as sock:
+        sock.bind(('127.0.0.1', 0))
+        port = sock.getsockname()[1]
+    secret = secrets.token_hex(32)
+    with tempfile.TemporaryDirectory(prefix='uwflow-preview-baseline-') as directory:
+        config = Path(directory) / 'compose.json'
+        write_json(config, {'services': {'hasura': {
+            'image': 'uwflow-preview-baseline', 'ports': [f'127.0.0.1:{port}:8080'],
+            'mem_limit': '768m', 'cpus': 0.5,
+            'environment': {'HASURA_GRAPHQL_DATABASE_URL': uri.replace('$', '$$'), 'HASURA_GRAPHQL_ADMIN_SECRET': secret,
+                            'HASURA_GRAPHQL_ENABLE_CONSOLE': 'false', 'HASURA_GRAPHQL_ENABLE_TELEMETRY': 'false'}}}})
+        command = ['docker', 'compose', '-p', 'uwflow-baseline-' + secrets.token_hex(4), '-f', str(config)]
+        headers = {'x-hasura-admin-secret': secret}
+        base = f'http://127.0.0.1:{port}'
+        try:
+            subprocess.run(command + ['up', '-d'], check=True, capture_output=True)
+            for _ in range(120):
+                try:
+                    result = api(base + '/v1/graphql', method='POST', headers=headers, body={'query': '{course{code}}'})
+                    if 'data' in result:
+                        break
+                except RuntimeError:
+                    pass
+                time.sleep(2)
+            else:
+                raise RuntimeError('Baseline migration failed; inspect local Docker logs before retrying')
+            sql = '\n'.join(line for line in (HERE / 'seed.sql').read_text().splitlines() if not line.startswith('\\'))
+            api(base + '/v2/query', method='POST', headers=headers,
+                body={'type': 'run_sql', 'args': {'source': 'default', 'sql': sql}})
+            result = api(base + '/v1/graphql', method='POST', headers=headers, body={'query': '{course(where:{code:{_eq:"cs135"}}){code}}'})
+            if not result.get('data', {}).get('course'):
+                raise RuntimeError('Baseline seed validation failed')
+            print('Baseline migrations and synthetic seed applied. Record this backend SHA with the baseline.')
+        finally:
+            subprocess.run(command + ['down', '--volumes', '--remove-orphans'], check=True, capture_output=True)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as error:
+        # Connection strings are deliberately absent from diagnostics.
+        raise SystemExit('Baseline setup failed: ' + (str(error) if isinstance(error, (ValueError, RuntimeError)) else type(error).__name__))

--- a/preview/config.example.json
+++ b/preview/config.example.json
@@ -1,0 +1,20 @@
+{
+  "frontend_repo": "UWFlow/uwflow_frontend",
+  "backend_repo": "UWFlow/uwflow",
+  "image_prefix": "ghcr.io/uwflow/uwflow-preview",
+  "domain": "preview-api.uwflow.com",
+  "max_previews": 1,
+  "max_ttl_hours": 24,
+  "min_available_memory_mb": 1536,
+  "min_free_disk_mb": 4096,
+  "port_start": 19000,
+  "neon_project": "REPLACE_WITH_SEPARATE_PREVIEW_PROJECT_ID",
+  "neon_parent": "REPLACE_WITH_SYNTHETIC_BASELINE_BRANCH_ID",
+  "neon_database": "flow_preview",
+  "neon_role": "flow_preview",
+  "neon_token": "REPLACE",
+  "github_token": "REPLACE_WITH_READ_ONLY_TOKEN",
+  "vercel_project": "REPLACE_WITH_DEDICATED_PREVIEW_PROJECT_ID",
+  "vercel_team": "REPLACE_WITH_TEAM_ID",
+  "vercel_token": "REPLACE"
+}

--- a/preview/controller.py
+++ b/preview/controller.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Root-owned preview control plane. No PR code is executed on the host."""
+import concurrent.futures
+import fcntl
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import secrets
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+
+ROOT = Path('/var/lib/uwflow-preview')
+CONFIG = Path('/etc/uwflow-preview/config.json')
+SHA = re.compile(r'[0-9a-f]{40}')
+
+
+def api(url, token='', method='GET', body=None, headers=None):
+    hdr = {'User-Agent': 'uwflow-preview', **(headers or {})}
+    if token:
+        hdr['Authorization'] = 'Bearer ' + token
+    if body is not None and not isinstance(body, bytes):
+        body = json.dumps(body).encode()
+        hdr['Content-Type'] = 'application/json'
+    req = urllib.request.Request(url, data=body, headers=hdr, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=45) as response:
+            data = response.read()
+            return json.loads(data) if data else {}
+    except urllib.error.HTTPError as error:
+        if method == 'DELETE' and error.code == 404:
+            return {}
+        # Provider bodies, URLs and subprocess output may contain credentials.
+        raise RuntimeError(f'Provider request failed: HTTP {error.code}') from None
+    except (urllib.error.URLError, TimeoutError):
+        raise RuntimeError('Provider request failed; retry reconciliation') from None
+
+
+def write_json(path, value):
+    temp = path.with_suffix('.tmp')
+    with temp.open('w') as output:
+        os.fchmod(output.fileno(), 0o600)
+        output.write(json.dumps(value, indent=2) + '\n')
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(temp, path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def validate(request, config):
+    action = request.get('action')
+    if action not in ('deploy', 'destroy', 'status', 'reconcile'):
+        raise ValueError('Unknown action')
+    if action in ('deploy', 'destroy'):
+        pr = request.get('pr')
+        if type(pr) is not int or not 1 <= pr <= 9999999:
+            raise ValueError('PR must be a positive integer')
+    if action == 'deploy':
+        for key in ('frontend_sha', 'backend_sha'):
+            if not SHA.fullmatch(request.get(key, '')):
+                raise ValueError('Full commit SHAs are required')
+        for service in ('api', 'hasura'):
+            pattern = re.escape(config['image_prefix'] + '-' + service) + r'@sha256:[0-9a-f]{64}'
+            if not re.fullmatch(pattern, request.get(service + '_image', '')):
+                raise ValueError('Only configured immutable preview images are allowed')
+        ttl = request.get('ttl_hours')
+        if type(ttl) is not int or not 1 <= ttl <= config['max_ttl_hours']:
+            raise ValueError('TTL exceeds host policy')
+    return request
+
+
+class Controller:
+    def __init__(self, config, root=ROOT):
+        self.c, self.root = config, root
+        if not re.fullmatch(r'[a-z0-9.-]+', config['domain']):
+            raise ValueError('Invalid preview domain')
+        if not 1 <= config['max_previews'] <= 10:
+            raise ValueError('Capacity must be 1–10')
+        self.state_path = root / 'state.json'
+        self.state = json.loads(self.state_path.read_text()) if self.state_path.exists() else {}
+
+    def save(self):
+        write_json(self.state_path, self.state)
+
+    def neon(self, path, method='GET', body=None):
+        base = 'https://console.neon.tech/api/v2/projects/' + self.c['neon_project']
+        return api(base + path, self.c['neon_token'], method, body)
+
+    def vercel(self, path, method='GET', body=None, headers=None):
+        sep = '&' if '?' in path else '?'
+        url = 'https://api.vercel.com' + path + sep + urllib.parse.urlencode({'teamId': self.c['vercel_team']})
+        return api(url, self.c['vercel_token'], method, body, headers)
+
+    def github_pr(self, pr):
+        return api(f"https://api.github.com/repos/{self.c['frontend_repo']}/pulls/{pr}", self.c['github_token'])
+
+    def wait_neon(self, result):
+        for operation in result.get('operations', []):
+            for _ in range(90):
+                status = self.neon('/operations/' + operation['id'])['operation']['status']
+                if status in ('finished', 'skipped'):
+                    break
+                if status in ('failed', 'cancelled'):
+                    raise RuntimeError('Neon operation failed')
+                time.sleep(2)
+            else:
+                raise RuntimeError('Neon operation timed out')
+
+    def branches(self):
+        result, cursor = [], None
+        while True:
+            query = urllib.parse.urlencode({'limit': 100, **({'cursor': cursor} if cursor else {})})
+            page = self.neon('/branches?' + query)
+            result.extend(page['branches'])
+            cursor = page.get('pagination', {}).get('next')
+            if not cursor:
+                return result
+
+    def run(self, *args, timeout=180):
+        result = subprocess.run(args, capture_output=True, timeout=timeout)
+        if result.returncode:
+            raise RuntimeError(f'{args[0]} failed (output withheld; inspect locally as root)')
+        return result.stdout.decode().strip()
+
+    def compose(self, record, *args):
+        return self.run('docker', 'compose', '-p', 'uwflow-preview-' + record['key'],
+                        '-f', str(self.root / record['key'] / 'compose.json'), *args)
+
+    def check_host_capacity(self):
+        available = next(int(line.split()[1]) * 1024 for line in Path('/proc/meminfo').read_text().splitlines()
+                         if line.startswith('MemAvailable:'))
+        if available < self.c['min_available_memory_mb'] * 1024 * 1024:
+            raise RuntimeError('Insufficient spare memory; resize EC2 or free a preview first')
+        docker_root = self.run('docker', 'info', '--format', '{{.DockerRootDir}}')
+        if shutil.disk_usage(docker_root).free < self.c['min_free_disk_mb'] * 1024 * 1024:
+            raise RuntimeError('Insufficient Docker disk space')
+
+    def reserve(self, req):
+        key = 'pr-' + str(req['pr'])
+        existing = self.state.get(key)
+        if existing and existing['phase'] != 'ready':
+            raise RuntimeError('Previous attempt needs cleanup before redeploying')
+        if not existing and len(self.state) >= self.c['max_previews']:
+            raise RuntimeError('Preview capacity full: ' + ', '.join(self.state))
+        used = {r['port'] for r in self.state.values()}
+        port = existing['port'] if existing else next(
+            p for p in range(self.c['port_start'], self.c['port_start'] + self.c['max_previews']) if p not in used)
+        record = existing or {'key': key, 'pr': req['pr'], 'port': port,
+                              'branch_name': 'uwflow-' + key + '-' + secrets.token_hex(8),
+                              'deployments': [], 'images': []}
+        record.update({k: req[k] for k in ('frontend_sha', 'backend_sha')})
+        record.update(phase='provisioning', expires_at=int(time.time()) + 1800)
+        record['images'] = list(set(record['images'] + [req['api_image'], req['hasura_image']]))
+        self.state[key] = record
+        self.save()  # Journal capacity + unique branch name BEFORE any external mutation.
+        return record
+
+    def setup_neon(self, record):
+        if not record.get('branch_id'):
+            found = [b for b in self.branches() if b['name'] == record['branch_name']]
+            if found:
+                branch = found[0]
+            else:
+                created = self.neon('/branches', 'POST', {
+                    'branch': {'name': record['branch_name'], 'parent_id': self.c['neon_parent']},
+                    'endpoints': [{'type': 'read_write', 'autoscaling_limit_min_cu': 0.25,
+                                   'autoscaling_limit_max_cu': 0.25, 'suspend_timeout_seconds': 300}]})
+                branch = created['branch']
+                record['branch_id'] = branch['id']
+                self.save()
+                self.wait_neon(created)
+            if branch['id'] == self.c['neon_parent'] or branch['parent_id'] != self.c['neon_parent']:
+                raise RuntimeError('Refusing non-preview Neon branch')
+            record['branch_id'] = branch['id']
+            self.save()
+            # Child roles initially inherit parent passwords. Never give these to PR code.
+            role = urllib.parse.quote(self.c['neon_role'], safe='')
+            self.wait_neon(self.neon(f"/branches/{branch['id']}/roles/{role}/reset_password", 'POST', {}))
+        query = urllib.parse.urlencode({'branch_id': record['branch_id'], 'database_name': self.c['neon_database'],
+                                       'role_name': self.c['neon_role'], 'pooled': 'false'})
+        uri = self.neon('/connection_uri?' + query)['uri']
+        parsed = urllib.parse.urlsplit(uri)
+        if parsed.scheme not in ('postgres', 'postgresql') or not parsed.hostname.endswith('.neon.tech'):
+            raise RuntimeError('Expected a Neon Postgres connection')
+        params = dict(urllib.parse.parse_qsl(parsed.query))
+        params['sslmode'] = 'verify-full'
+        params['sslrootcert'] = '/etc/ssl/certs/ca-certificates.crt'
+        # pgx uses TLS verification; channel_binding is a libpq-only URL parameter.
+        params.pop('channel_binding', None)
+        return urllib.parse.urlunsplit(parsed._replace(query=urllib.parse.urlencode(params)))
+
+    def config_stack(self, record, req, uri):
+        directory = self.root / record['key']
+        directory.mkdir(mode=0o700, exist_ok=True)
+        jwt_path = directory / 'jwt'
+        if not jwt_path.exists():
+            jwt_path.write_text(secrets.token_hex(32))
+            jwt_path.chmod(0o600)
+        jwt = jwt_path.read_text()
+        common = {'restart': 'unless-stopped', 'cpus': 0.5, 'pids_limit': 128,
+                  'cap_drop': ['ALL'], 'security_opt': ['no-new-privileges:true'],
+                  'logging': {'driver': 'json-file', 'options': {'max-size': '5m', 'max-file': '2'}}}
+        admin = secrets.token_hex(32)
+        gateway = '''worker_processes 1;
+pid /var/run/nginx.pid;
+events { worker_connections 256; }
+http {
+include /etc/nginx/mime.types;
+server {
+  listen 8080;
+  client_max_body_size 10m;
+  location = /healthz { proxy_pass http://hasura:8080/healthz; }
+  location = /graphql { proxy_pass http://hasura:8080/v1/graphql; }
+  location /api/ { proxy_pass http://api:8081/; }
+  location / { return 404; }
+}
+}
+'''
+        (directory / 'gateway.conf').write_text(gateway)
+        # The nginx worker is unprivileged; the config contains no secrets.
+        (directory / 'gateway.conf').chmod(0o644)
+        config = {'services': {
+            'api': {**common, 'image': req['api_image'], 'mem_limit': '256m', 'read_only': True,
+                    'user': '65534:65534', 'tmpfs': ['/tmp:size=32m'], 'environment': {
+                        'DATABASE_URL': uri + '&pool_max_conns=5', 'API_PORT': '8081',
+                        'HASURA_GRAPHQL_JWT_KEY': jwt, 'RUN_MODE': 'preview', 'UW_API_KEY_V3': '',
+                        **{k: '' for k in ('POSTGRES_DB', 'POSTGRES_HOST', 'POSTGRES_PORT', 'POSTGRES_USER', 'POSTGRES_PASSWORD')}}},
+            'hasura': {**common, 'image': req['hasura_image'], 'mem_limit': '768m',
+                       'environment': {'HASURA_GRAPHQL_DATABASE_URL': uri,
+                           'HASURA_GRAPHQL_ADMIN_SECRET': admin,
+                           'HASURA_GRAPHQL_JWT_SECRET': json.dumps({'type': 'HS256', 'key': jwt}),
+                           'HASURA_GRAPHQL_UNAUTHORIZED_ROLE': 'anonymous',
+                           'HASURA_GRAPHQL_ENABLE_CONSOLE': 'false', 'HASURA_GRAPHQL_ENABLE_TELEMETRY': 'false',
+                           'HASURA_GRAPHQL_CORS_DOMAIN': 'https://invalid.invalid',
+                           'HASURA_GRAPHQL_PG_CONNECTIONS': '10', 'HASURA_GRAPHQL_LOG_LEVEL': 'warn'}},
+            'gateway': {**common, 'image': 'nginx:1.28-alpine', 'mem_limit': '64m',
+                        'user': '101:101', 'read_only': True,
+                        'tmpfs': ['/var/cache/nginx:size=16m,uid=101,gid=101', '/var/run:size=1m,uid=101,gid=101', '/tmp:size=1m'],
+                        'volumes': [str(directory / 'gateway.conf') + ':/etc/nginx/nginx.conf:ro'],
+                        'ports': [f"127.0.0.1:{record['port']}:8080"],
+                        'networks': {'default': {}, 'edge': {'aliases': ['preview-' + record['key']]}},
+                        'depends_on': ['api', 'hasura']}},
+            'networks': {'edge': {'external': True, 'name': 'uwflow-preview-edge'}}}
+        # Compose interpolates dollars even inside JSON strings. Preserve literal credentials.
+        for service in config['services'].values():
+            if 'environment' in service:
+                service['environment'] = {key: value.replace('$', '$$')
+                                          for key, value in service['environment'].items()}
+        write_json(directory / 'compose.json', config)
+
+    def ready(self, record):
+        base = f"http://127.0.0.1:{record['port']}"
+        for _ in range(90):
+            try:
+                result = api(base + '/graphql', method='POST', body={'query': '{course(where:{code:{_eq:"cs135"}}){code}}'})
+                if result.get('data', {}).get('course'):
+                    # Empty search still exercises Go -> Neon SQL connectivity.
+                    api(base + '/api/data/search')
+                    return
+            except RuntimeError:
+                pass
+            time.sleep(2)
+        raise RuntimeError('API/Hasura readiness failed; verify baseline schema and seed')
+
+    def frontend_files(self, record):
+        # Read public source without executing it, extracting it, or following symlinks.
+        url = f"https://codeload.github.com/{self.c['frontend_repo']}/zip/{record['frontend_sha']}"
+        with urllib.request.urlopen(url, timeout=45) as response:
+            archive = response.read(50 * 1024 * 1024 + 1)
+        if len(archive) > 50 * 1024 * 1024:
+            raise RuntimeError('Frontend archive too large')
+        files, total = {}, 0
+        with zipfile.ZipFile(io.BytesIO(archive)) as zipped:
+            for item in zipped.infolist():
+                path = PurePosixPath(item.filename)
+                relative = PurePosixPath(*path.parts[1:])
+                if item.is_dir():
+                    continue
+                if path.is_absolute() or '..' in path.parts or (item.external_attr >> 16) & 0o170000 == 0o120000:
+                    raise ValueError('Unsafe archive member')
+                if relative.parts[0] in ('.git', '.github', '.agents', '.circleci', '.vercel', 'e2e', 'node_modules') or relative.name.startswith('.env'):
+                    continue
+                total += item.file_size
+                if total > 50 * 1024 * 1024 or len(files) >= 10000:
+                    raise ValueError('Expanded source exceeds limit')
+                files[str(relative)] = zipped.read(item)
+        base = f"https://{record['key']}.{self.c['domain']}"
+        # Replace production rewrites in the uploaded copy only. Same-origin auth/GraphQL.
+        files['vercel.json'] = json.dumps({
+            'buildCommand': 'REACT_APP_BACKEND_ENDPOINT=/api REACT_APP_GRAPHQL_ENDPOINT=/graphql bun run build:vercel',
+            'installCommand': 'bun install --frozen-lockfile', 'outputDirectory': 'build',
+            'rewrites': [{'source': '/graphql', 'destination': base + '/graphql'},
+                         {'source': '/api/:path*', 'destination': base + '/api/:path*'},
+                         {'source': '/(.*)', 'destination': '/index.html'}]}).encode()
+        return files
+
+    def deploy_frontend(self, record):
+        files = self.frontend_files(record)
+        def upload(item):
+            name, data = item
+            digest = hashlib.sha1(data).hexdigest()
+            self.vercel('/v2/files', 'POST', data, {'Content-Type': 'application/octet-stream',
+                                                  'x-vercel-digest': digest, 'Content-Length': str(len(data))})
+            return {'file': name, 'sha': digest, 'size': len(data)}
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            uploaded = list(executor.map(upload, files.items()))
+        deployment = self.vercel('/v13/deployments', 'POST', {
+            'name': 'uwflow-preview', 'project': self.c['vercel_project'], 'files': uploaded,
+            'meta': {'uwflowPreview': record['branch_name'], 'frontendSha': record['frontend_sha'],
+                     'backendSha': record['backend_sha']}})
+        record['deployments'].append(deployment['id'])
+        self.save()
+        for _ in range(180):
+            result = self.vercel('/v13/deployments/' + deployment['id'])
+            if result['readyState'] == 'READY':
+                record['url'] = 'https://' + result['url']
+                # Retire the previous frontend only after replacement is ready.
+                for old in record['deployments'][:-1]:
+                    self.vercel('/v13/deployments/' + old, 'DELETE')
+                record['deployments'] = [deployment['id']]
+                return
+            if result['readyState'] in ('ERROR', 'CANCELED'):
+                raise RuntimeError('Vercel build failed; inspect deployment in Vercel')
+            time.sleep(5)
+        raise RuntimeError('Vercel build timed out')
+
+    def deploy(self, req):
+        pr = self.github_pr(req['pr'])
+        if pr['state'] != 'open' or pr['head']['sha'] != req['frontend_sha']:
+            raise ValueError('PR closed or changed since approval; request a new deployment')
+        if pr['head']['repo']['full_name'] != self.c['frontend_repo']:
+            raise ValueError('Fork previews require a maintainer-owned branch')
+        self.check_host_capacity()
+        record = self.reserve(req)
+        try:
+            uri = self.setup_neon(record)
+            directory = self.root / record['key']
+            if (directory / 'compose.json').exists():
+                self.compose(record, 'down', '--remove-orphans')
+            self.config_stack(record, req, uri)
+            self.compose(record, 'pull')
+            self.compose(record, 'up', '-d')
+            self.ready(record)
+            self.deploy_frontend(record)
+            if self.github_pr(req['pr'])['state'] != 'open':
+                raise RuntimeError('PR closed during deployment')
+            current_images = {req['api_image'], req['hasura_image']}
+            for old in record['images'][:]:
+                if old not in current_images:
+                    try:
+                        self.run('docker', 'image', 'rm', old)
+                        record['images'].remove(old)
+                    except RuntimeError:
+                        pass
+            record.update(phase='ready', expires_at=int(time.time()) + req['ttl_hours'] * 3600)
+            self.save()
+            return self.status()
+        except Exception:
+            record['phase'] = 'deleting'
+            self.save()
+            try:
+                self.destroy(record['key'])
+            except Exception:
+                pass  # Journal remains; timer retries. Never hide the original error.
+            raise
+
+    def destroy(self, key):
+        record = self.state.get(key)
+        if not record:
+            return
+        record['phase'] = 'deleting'
+        self.save()
+        directory = self.root / key
+        if (directory / 'compose.json').exists():
+            self.compose(record, 'down', '--remove-orphans', '--volumes')
+        # Stop EC2 compute FIRST, even when either cloud API is unavailable.
+        # Recover successful cloud POSTs whose response was lost before journaling.
+        for branch in self.branches():
+            if branch['name'] == record['branch_name']:
+                if branch['id'] == self.c['neon_parent'] or branch['parent_id'] != self.c['neon_parent']:
+                    raise RuntimeError('Refusing to delete non-preview branch')
+                self.wait_neon(self.neon('/branches/' + branch['id'], 'DELETE'))
+        until = None
+        while True:
+            query = {'projectId': self.c['vercel_project'], 'limit': 100}
+            if until:
+                query['until'] = until
+            page = self.vercel('/v6/deployments?' + urllib.parse.urlencode(query))
+            for deployment in page['deployments']:
+                if deployment.get('meta', {}).get('uwflowPreview') == record['branch_name']:
+                    self.vercel('/v13/deployments/' + deployment['uid'], 'DELETE')
+            until = page.get('pagination', {}).get('next')
+            if not until:
+                break
+        for image in record['images']:
+            # Never force/remove shared images or run a global Docker prune.
+            if not any(image in other['images'] for other_key, other in self.state.items() if other_key != key):
+                try:
+                    self.run('docker', 'image', 'rm', image)
+                except RuntimeError:
+                    pass
+        if directory.exists():
+            shutil.rmtree(directory)
+        del self.state[key]
+        self.save()
+
+    def reconcile(self):
+        errors = []
+        for key, record in list(self.state.items()):
+            # TTL is independent of GitHub availability, including after host reboot.
+            expired = record['expires_at'] <= time.time() or record['phase'] == 'deleting'
+            try:
+                closed = False if expired else self.github_pr(record['pr'])['state'] == 'closed'
+                if expired or closed:
+                    self.destroy(key)
+            except Exception:
+                errors.append(key)
+        if errors:
+            raise RuntimeError('Reconciliation pending for: ' + ', '.join(errors))
+        return self.status()
+
+    def status(self):
+        return [{k: record.get(k) for k in ('key', 'phase', 'url', 'frontend_sha', 'backend_sha', 'expires_at')}
+                for record in self.state.values()]
+
+
+def main():
+    # Hard bound prevents a hung deploy holding the lock indefinitely. Journal survives SIGALRM.
+    signal.alarm(25 * 60)
+    os.umask(0o077)
+    ROOT.mkdir(mode=0o700, parents=True, exist_ok=True)
+    config = json.loads(CONFIG.read_text())
+    if sys.argv[1:] == ['request']:
+        data = sys.stdin.buffer.read(8193)
+        if len(data) > 8192:
+            raise ValueError('Request too large')
+        request = json.loads(data)
+    elif sys.argv[1:] == ['reconcile']:
+        request = {'action': 'reconcile'}
+    else:
+        raise ValueError('Use request (JSON on stdin) or reconcile')
+    validate(request, config)
+    with (ROOT / 'lock').open('w') as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        controller = Controller(config)
+        action = request['action']
+        if action == 'deploy':
+            result = controller.deploy(request)
+        elif action == 'destroy':
+            controller.destroy('pr-' + str(request['pr']))
+            result = controller.status()
+        else:
+            result = getattr(controller, action)()
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as error:
+        # Suppress untrusted provider payloads, DB URIs and subprocess output.
+        print('Preview operation failed: ' + (str(error) if isinstance(error, (ValueError, RuntimeError))
+                                             else type(error).__name__), file=sys.stderr)
+        sys.exit(1)

--- a/preview/edge.conf.example
+++ b/preview/edge.conf.example
@@ -1,0 +1,17 @@
+# Copy to the existing nginx/config/preview.conf AFTER replacing the domain.
+# Attach the existing frontend proxy to the external uwflow-preview-edge network.
+# /ssl/preview/ must contain a certificate valid for *.preview-api.uwflow.com.
+server {
+    listen 443 ssl;
+    server_name ~^pr-(?<preview_pr>[1-9][0-9]*)\.preview-api\.uwflow\.com$;
+    ssl_certificate /ssl/preview/fullchain.pem;
+    ssl_certificate_key /ssl/preview/privkey.pem;
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    location / {
+        set $preview_upstream preview-pr-$preview_pr;
+        proxy_pass http://$preview_upstream:8080;
+        proxy_set_header Host $host;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+    }
+}

--- a/preview/production-edge.override.yml
+++ b/preview/production-edge.override.yml
@@ -1,0 +1,10 @@
+# Use only when configuring the existing production reverse proxy, not previews.
+services:
+  frontend:
+    networks:
+      - default
+      - preview-edge
+networks:
+  preview-edge:
+    external: true
+    name: uwflow-preview-edge

--- a/preview/request.py
+++ b/preview/request.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Serialize workflow inputs; never interpolate PR input into a shell command."""
+import json
+import os
+
+request = {'action': os.environ['PREVIEW_ACTION']}
+if request['action'] in ('deploy', 'destroy'):
+    request['pr'] = int(os.environ['PREVIEW_PR'])
+if request['action'] == 'deploy':
+    request.update({key: os.environ[key.upper()] for key in
+                    ('frontend_sha', 'backend_sha', 'api_image', 'hasura_image')})
+    request['ttl_hours'] = int(os.environ['TTL_HOURS'])
+print(json.dumps(request))

--- a/preview/resolve.py
+++ b/preview/resolve.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Resolve immutable revisions BEFORE the protected environment approval."""
+import json
+import os
+import re
+import subprocess
+
+
+def get(path):
+    return json.loads(subprocess.check_output(['gh', 'api', path]))
+
+
+def main():
+    action, pr = os.environ['PREVIEW_ACTION'], os.environ['PREVIEW_PR']
+    if action not in ('deploy', 'destroy', 'status'):
+        raise ValueError('Invalid action')
+    if action != 'status' and not re.fullmatch(r'[1-9][0-9]{0,6}', pr):
+        raise ValueError('Invalid PR number')
+    frontend, backend = '', ''
+    if action == 'deploy':
+        pull = get('repos/UWFlow/uwflow_frontend/pulls/' + pr)
+        if pull['state'] != 'open' or pull['head']['repo']['full_name'] != 'UWFlow/uwflow_frontend':
+            raise ValueError('Choose an open PR on a maintainer-owned frontend branch')
+        frontend = pull['head']['sha']
+        backend = os.environ.get('PREVIEW_BACKEND_SHA') or get('repos/UWFlow/uwflow/commits/main')['sha']
+        if not re.fullmatch(r'[0-9a-f]{40}', backend):
+            raise ValueError('Backend revision must be a full SHA')
+        get('repos/UWFlow/uwflow/commits/' + backend)
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
+        out.write(f'frontend_sha={frontend}\nbackend_sha={backend}\n')
+    with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as out:
+        out.write(f'Action: **{action}**\n\nFrontend PR #{pr}: `{frontend}`\n\nBackend: `{backend}`\n')
+        out.write('\nReview these exact commits before approving the `ec2-preview` environment.\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/preview/seed.sql
+++ b/preview/seed.sql
@@ -1,0 +1,10 @@
+\set ON_ERROR_STOP on
+BEGIN;
+INSERT INTO term (id, start_date, end_date)
+VALUES (1261, '2026-01-01', '2026-04-30') ON CONFLICT DO NOTHING;
+INSERT INTO course (code, name, description)
+VALUES ('cs135', 'Preview Introduction to Computer Science', 'Synthetic review test course.')
+ON CONFLICT DO NOTHING;
+INSERT INTO prof (code, name) VALUES ('preview_professor', 'Preview Professor')
+ON CONFLICT DO NOTHING;
+COMMIT;

--- a/preview/smoke.py
+++ b/preview/smoke.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Terminal-only integration test using disposable Postgres, no cloud credentials."""
+import json
+from pathlib import Path
+import secrets
+import socket
+import subprocess
+import tempfile
+import time
+
+from controller import Controller, api, write_json
+
+HERE = Path(__file__).resolve().parent
+
+
+def run(*args, data=None):
+    result = subprocess.run(args, input=data, capture_output=True)
+    if result.returncode:
+        raise RuntimeError('Smoke test command failed: ' + ' '.join(args[:3]) + '\n' + result.stderr.decode())
+    return result.stdout.decode()
+
+
+def main():
+    suffix = secrets.token_hex(5)
+    edge = 'uwflow-preview-smoke-' + suffix
+    config = json.loads((HERE / 'config.example.json').read_text())
+    with tempfile.TemporaryDirectory(prefix='uwflow-preview-smoke-') as temp:
+        controller = Controller(config, Path(temp))
+        with socket.socket() as sock:
+            sock.bind(('127.0.0.1', 0))
+            port = sock.getsockname()[1]
+        record = {'key': 'smoke-' + suffix, 'port': port}
+        request = {'api_image': 'uwflow-preview-api-validation', 'hasura_image': 'uwflow-preview-hasura-validation'}
+        password = secrets.token_hex(20)
+        uri = f'postgres://preview:{password}@postgres:5432/preview?sslmode=disable'
+        controller.config_stack(record, request, uri)
+        compose_path = Path(temp) / record['key'] / 'compose.json'
+        stack = json.loads(compose_path.read_text())
+        stack['networks']['edge']['name'] = edge
+        stack['services']['postgres'] = {
+            'image': 'postgres:15-alpine', 'environment': {'POSTGRES_USER': 'preview', 'POSTGRES_PASSWORD': password, 'POSTGRES_DB': 'preview'},
+            'tmpfs': ['/var/lib/postgresql/data'], 'mem_limit': '256m', 'cpus': 0.5}
+        write_json(compose_path, stack)
+        project = 'uwflow-preview-' + record['key']
+        command = ['docker', 'compose', '-p', project, '-f', str(compose_path)]
+        run('docker', 'network', 'create', edge)
+        try:
+            run(*command, 'up', '-d', 'postgres')
+            for _ in range(60):
+                try:
+                    run(*command, 'exec', '-T', 'postgres', 'pg_isready', '-U', 'preview')
+                    break
+                except RuntimeError:
+                    time.sleep(1)
+            else:
+                raise RuntimeError('Postgres startup timed out')
+            run(*command, 'up', '-d')
+            base = f'http://127.0.0.1:{port}'
+            for _ in range(120):
+                try:
+                    data = api(base + '/graphql', method='POST', body={'query': '{course{code}}'})
+                    if 'data' in data:
+                        break
+                except RuntimeError:
+                    pass
+                time.sleep(2)
+            else:
+                raise RuntimeError('Hasura migrations/startup failed')
+            run(*command, 'exec', '-T', 'postgres', 'psql', '-U', 'preview', '-d', 'preview', data=(HERE / 'seed.sql').read_bytes())
+            controller.ready(record)
+            body = {'first_name': 'Preview', 'last_name': 'Smoke', 'email': f'preview-{suffix}@example.test', 'password': password}
+            registered = api(base + '/api/auth/email/register', method='POST', body=body)
+            login = api(base + '/api/auth/email/login', method='POST', body=body)
+            assert registered['user_id'] == login['user_id'] and login['token']
+            def gql(query, variables=None, admin=False):
+                headers = {'x-hasura-admin-secret': stack['services']['hasura']['environment']['HASURA_GRAPHQL_ADMIN_SECRET']} if admin else {}
+                result = api(base + '/graphql', token='' if admin else login['token'], method='POST',
+                             body={'query': query, 'variables': variables or {}}, headers=headers)
+                if result.get('errors'):
+                    raise RuntimeError('GraphQL smoke check failed: ' + json.dumps(result['errors']))
+                return result['data']
+            course = gql('{course(where:{code:{_eq:"cs135"}}){id}}')['course'][0]['id']
+            gql('mutation($u:Int!,$c:Int!){insert_user_course_taken_one(object:{user_id:$u,course_id:$c,term_id:1261}){user_id}}',
+                {'u': login['user_id'], 'c': course}, admin=True)
+            review = gql('mutation($u:Int!,$c:Int!){insert_review_one(object:{user_id:$u,course_id:$c,liked:1,course_comment:"Preview smoke review",public:true}){id}}',
+                         {'u': login['user_id'], 'c': course})['insert_review_one']['id']
+            edited = gql('mutation($id:Int!){update_review_by_pk(pk_columns:{id:$id},_set:{course_comment:"Edited preview review"}){course_comment}}', {'id': review})
+            assert edited['update_review_by_pk']['course_comment'] == 'Edited preview review'
+            # Account deletion intentionally anonymizes reviews; remove our own review first.
+            gql('mutation($id:Int!){delete_review_by_pk(id:$id){id}}', {'id': review})
+            api(base + '/api/user', token=login['token'], method='DELETE')
+            assert not gql('query($id:Int!){user(where:{id:{_eq:$id}}){id}}', {'id': login['user_id']}, admin=True)['user']
+            assert not gql('query($id:Int!){review(where:{id:{_eq:$id}}){id}}', {'id': review}, admin=True)['review']
+            print('PASS: migrations, synthetic seed, API/Hasura routing, signup, login, review creation/editing, account cleanup')
+        except Exception:
+            # CI stack has synthetic credentials only; retain terminal diagnostics on failure.
+            print(run(*command, 'logs', '--tail', '8')[-10000:])
+            raise
+        finally:
+            run(*command, 'down', '--volumes', '--remove-orphans')
+            run('docker', 'network', 'rm', edge)
+            print('Disposable smoke stack removed')
+
+
+if __name__ == '__main__':
+    main()

--- a/preview/ssh-command
+++ b/preview/ssh-command
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Install root-owned; use as authorized_keys forced command with restrict.
+# Never evaluate SSH_ORIGINAL_COMMAND. Input is one bounded JSON request.
+exec sudo -n /usr/bin/python3 /opt/uwflow-preview/controller.py request

--- a/preview/tests/test_controller.py
+++ b/preview/tests/test_controller.py
@@ -1,0 +1,292 @@
+import io
+import json
+from pathlib import Path
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+import zipfile
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from controller import Controller, validate, write_json
+
+CONFIG = json.loads((Path(__file__).resolve().parents[1] / 'config.example.json').read_text())
+REQUEST = {'action': 'deploy', 'pr': 42, 'frontend_sha': 'a' * 40, 'backend_sha': 'b' * 40,
+           'api_image': CONFIG['image_prefix'] + '-api@sha256:' + 'c' * 64,
+           'hasura_image': CONFIG['image_prefix'] + '-hasura@sha256:' + 'd' * 64, 'ttl_hours': 24}
+
+
+class Fake(Controller):
+    def __init__(self, root):
+        super().__init__(CONFIG, root)
+        self.calls = []
+        self.cloud_branches = []
+        self.closed = False
+        self.cloud_failure = False
+
+    def github_pr(self, pr):
+        if self.cloud_failure:
+            raise RuntimeError('GitHub unavailable')
+        return {'state': 'closed' if self.closed else 'open',
+                'head': {'sha': REQUEST['frontend_sha'], 'repo': {'full_name': CONFIG['frontend_repo']}}}
+
+    def run(self, *args, **kwargs):
+        self.calls.append(args)
+        return ''
+
+    def branches(self):
+        if self.cloud_failure:
+            raise RuntimeError('Neon unavailable')
+        return self.cloud_branches
+
+    def neon(self, path, method='GET', body=None):
+        self.calls.append(('neon', path, method, body))
+        return {}
+
+    def vercel(self, path, method='GET', body=None, headers=None):
+        self.calls.append(('vercel', path, method, body))
+        return {'deployments': [], 'pagination': {}}
+
+    def check_host_capacity(self):
+        pass
+
+    def setup_neon(self, record):
+        return 'postgres://example'
+
+    def config_stack(self, record, req, uri):
+        pass
+
+    def ready(self, record):
+        pass
+
+    def deploy_frontend(self, record):
+        record['url'] = 'https://preview.vercel.app'
+
+
+class LifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.controller = Fake(self.root)
+        self.controller.c = {**CONFIG, 'max_previews': 2}
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def record(self):
+        record = self.controller.reserve(REQUEST)
+        directory = self.root / record['key']
+        directory.mkdir(exist_ok=True)
+        write_json(directory / 'compose.json', {})
+        return record
+
+    def test_capacity_survives_process_restart_and_counts_pending_cleanup(self):
+        record = self.record()
+        record['phase'] = 'deleting'
+        self.controller.save()
+        second = {**REQUEST, 'pr': 43}
+        self.controller.reserve(second)
+        restarted = Controller(self.controller.c, self.root)
+        with self.assertRaisesRegex(RuntimeError, 'capacity full'):
+            restarted.reserve({**REQUEST, 'pr': 44})
+        self.assertEqual(len(restarted.state), 2)
+
+    def test_updates_reuse_branch_port_and_preserve_database_identity(self):
+        record = self.record()
+        record.update(phase='ready', branch_id='br-isolated')
+        self.controller.save()
+        updated = self.controller.reserve(REQUEST)
+        self.assertEqual(updated['branch_id'], 'br-isolated')
+        self.assertEqual(updated['branch_name'], record['branch_name'])
+        self.assertEqual(updated['port'], record['port'])
+        self.assertEqual(len(self.controller.state), 1)
+
+    def test_expiry_stops_containers_during_provider_outage_and_retries(self):
+        record = self.record()
+        record['expires_at'] = 0
+        self.controller.cloud_failure = True
+        with self.assertRaisesRegex(RuntimeError, 'pending'):
+            self.controller.reconcile()
+        self.assertIn('down', self.controller.calls[0])
+        self.assertIn('pr-42', self.controller.state)
+        self.controller.cloud_failure = False
+        self.controller.reconcile()
+        self.assertEqual(self.controller.state, {})
+
+    def test_closed_pr_is_cleaned_without_waiting_for_ttl(self):
+        self.record()
+        self.controller.closed = True
+        self.controller.reconcile()
+        self.assertEqual(self.controller.state, {})
+
+    def test_open_unexpired_preview_is_untouched(self):
+        self.record()
+        self.controller.reconcile()
+        self.assertEqual(self.controller.calls, [])
+
+    def test_recovers_neon_create_with_lost_response_and_never_deletes_baseline(self):
+        record = self.record()
+        self.controller.cloud_branches = [
+            {'name': 'baseline', 'id': CONFIG['neon_parent'], 'parent_id': None},
+            {'name': record['branch_name'], 'id': 'br-child', 'parent_id': CONFIG['neon_parent']}]
+        self.controller.destroy('pr-42')
+        self.assertEqual([c[1] for c in self.controller.calls if c[0] == 'neon'], ['/branches/br-child'])
+        self.controller.destroy('pr-42')  # Idempotent after successful cleanup.
+
+    def test_refuses_cleanup_if_branch_ownership_does_not_match(self):
+        record = self.record()
+        self.controller.cloud_branches = [{'name': record['branch_name'], 'id': CONFIG['neon_parent'], 'parent_id': None}]
+        with self.assertRaisesRegex(RuntimeError, 'non-preview'):
+            self.controller.destroy('pr-42')
+        self.assertFalse(any(c[0] == 'neon' for c in self.controller.calls))
+
+    def test_changed_pr_fails_before_reservation_or_compute(self):
+        with self.assertRaisesRegex(ValueError, 'changed'):
+            self.controller.deploy({**REQUEST, 'frontend_sha': 'e' * 40})
+        self.assertEqual(self.controller.state, {})
+        self.assertEqual(self.controller.calls, [])
+
+    def test_failure_after_reservation_rolls_back_and_releases_capacity(self):
+        self.controller.ready = lambda record: (_ for _ in ()).throw(RuntimeError('not ready'))
+        with self.assertRaisesRegex(RuntimeError, 'not ready'):
+            self.controller.deploy(REQUEST)
+        self.assertEqual(self.controller.state, {})
+
+    def test_never_forces_image_removal_or_prunes_other_projects(self):
+        self.record()
+        self.controller.destroy('pr-42')
+        commands = repr(self.controller.calls)
+        self.assertNotIn('prune', commands)
+        self.assertNotIn('--force', commands)
+        self.assertNotIn('backend_postgres', commands)
+
+    def test_lost_vercel_response_recovered_by_ownership_metadata(self):
+        record = self.record()
+        calls = []
+        def vercel(path, method='GET', body=None, headers=None):
+            calls.append((path, method))
+            return {'deployments': [
+                {'uid': 'dpl-owned', 'meta': {'uwflowPreview': record['branch_name']}},
+                {'uid': 'dpl-other', 'meta': {'uwflowPreview': 'another'}}], 'pagination': {}}
+        self.controller.vercel = vercel
+        self.controller.destroy('pr-42')
+        self.assertIn(('/v13/deployments/dpl-owned', 'DELETE'), calls)
+        self.assertNotIn(('/v13/deployments/dpl-other', 'DELETE'), calls)
+
+    def test_status_contains_no_secrets(self):
+        record = self.record()
+        record['database_url'] = 'do-not-print'
+        self.assertNotIn('do-not-print', json.dumps(self.controller.status()))
+
+
+class ConfigurationTests(unittest.TestCase):
+    def test_neon_setup_waits_for_rotation_and_enforces_verified_tls(self):
+        with tempfile.TemporaryDirectory() as directory:
+            controller = Controller(CONFIG, Path(directory))
+            record = controller.reserve(REQUEST)
+            calls = []
+            def neon(path, method='GET', body=None):
+                calls.append((path, method, body))
+                if path.startswith('/branches?'):
+                    return {'branches': []}
+                if path == '/branches':
+                    return {'branch': {'id': 'br-child', 'parent_id': CONFIG['neon_parent']},
+                            'operations': [{'id': 'op-create'}]}
+                if path.endswith('/reset_password'):
+                    return {'operations': [{'id': 'op-password'}]}
+                if path.startswith('/operations/'):
+                    return {'operation': {'status': 'finished'}}
+                if path.startswith('/connection_uri?'):
+                    return {'uri': 'postgres://preview:rotated@ep-child.neon.tech/flow_preview?sslmode=require&channel_binding=require'}
+                raise AssertionError(path)
+            controller.neon = neon
+            uri = controller.setup_neon(record)
+            self.assertIn('sslmode=verify-full', uri)
+            self.assertIn('sslrootcert=', uri)
+            self.assertNotIn('channel_binding', uri)
+            paths = [call[0] for call in calls]
+            self.assertLess(paths.index('/operations/op-create'), paths.index('/operations/op-password'))
+            self.assertTrue(paths[-1].startswith('/connection_uri?'))
+            self.assertIn('branch_id=br-child', paths[-1])
+            self.assertIn('pooled=false', paths[-1])
+
+    def test_neon_branch_pagination_uses_provider_next_cursor(self):
+        with tempfile.TemporaryDirectory() as directory:
+            controller = Controller(CONFIG, Path(directory))
+            paths = []
+            def neon(path):
+                paths.append(path)
+                return ({'branches': [{'id': 'second'}]} if 'cursor=next-page' in path else
+                        {'branches': [{'id': 'first'}], 'pagination': {'next': 'next-page'}})
+            controller.neon = neon
+            self.assertEqual([b['id'] for b in controller.branches()], ['first', 'second'])
+            self.assertEqual(len(paths), 2)
+
+    def test_rejects_injection_mutable_images_and_unbounded_ttl(self):
+        for field, value in [('pr', '../production'), ('pr', True), ('frontend_sha', 'main'),
+                             ('backend_sha', 'a' * 40 + ';id'), ('api_image', 'evil/api:latest'),
+                             ('ttl_hours', 9999), ('ttl_hours', True)]:
+            with self.subTest(field=field, value=value), self.assertRaises(ValueError):
+                validate({**REQUEST, field: value}, CONFIG)
+        self.assertEqual(validate(REQUEST, CONFIG), REQUEST)
+
+    def test_generated_stack_is_bounded_and_has_no_production_mounts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            controller = Controller(CONFIG, root)
+            record = controller.reserve(REQUEST)
+            controller.config_stack(record, REQUEST, 'postgres://preview:secret$literal@ep-test.neon.tech/flow?sslmode=verify-full')
+            path = root / 'pr-42' / 'compose.json'
+            config = json.loads(path.read_text())
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+            self.assertNotIn('volumes', config)
+            for service in config['services'].values():
+                self.assertIn('mem_limit', service)
+                self.assertIn('cpus', service)
+                self.assertIn('pids_limit', service)
+                self.assertEqual(service['cap_drop'], ['ALL'])
+                self.assertNotIn('container_name', service)
+                self.assertNotIn('privileged', service)
+            api_service = config['services']['api']
+            self.assertTrue(api_service['read_only'])
+            self.assertNotIn('ports', api_service)
+            self.assertNotIn('edge', api_service.get('networks', {}))
+            self.assertIn('secret$$literal', api_service['environment']['DATABASE_URL'])
+            self.assertIn('sslmode=verify-full', api_service['environment']['DATABASE_URL'])
+            self.assertIn('pool_max_conns=5', api_service['environment']['DATABASE_URL'])
+            self.assertNotIn('docker.sock', json.dumps(config))
+
+    def test_uploaded_frontend_replaces_production_routes_without_modifying_source(self):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w') as archive:
+            archive.writestr('repo/vercel.json', '{"rewrites":[{"destination":"https://uwflow.com/api"}]}')
+            archive.writestr('repo/.env', 'production-secret')
+            archive.writestr('repo/.eslintrc.js', 'module.exports = {}')
+            archive.writestr('repo/package.json', '{}')
+        with tempfile.TemporaryDirectory() as directory:
+            controller = Controller(CONFIG, Path(directory))
+            record = controller.reserve(REQUEST)
+            with patch('urllib.request.urlopen', return_value=io.BytesIO(buffer.getvalue())):
+                files = controller.frontend_files(record)
+            config = json.loads(files['vercel.json'])
+            self.assertIn('bun run build:vercel', config['buildCommand'])
+            self.assertNotIn('https://uwflow.com', files['vercel.json'].decode())
+            self.assertIn('pr-42.preview-api.uwflow.com', files['vercel.json'].decode())
+            self.assertNotIn('.env', files)
+            self.assertIn('.eslintrc.js', files)
+
+    def test_archive_path_traversal_is_rejected(self):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w') as archive:
+            archive.writestr('repo/../bad', 'bad')
+        with tempfile.TemporaryDirectory() as directory:
+            controller = Controller(CONFIG, Path(directory))
+            record = controller.reserve(REQUEST)
+            with patch('urllib.request.urlopen', return_value=io.BytesIO(buffer.getvalue())):
+                with self.assertRaisesRegex(ValueError, 'Unsafe'):
+                    controller.frontend_files(record)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/preview/uwflow-preview-gc.service
+++ b/preview/uwflow-preview-gc.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Expire UWFlow previews and reconcile closed PRs
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 /opt/uwflow-preview/controller.py reconcile
+TimeoutStartSec=25min
+UMask=0077

--- a/preview/uwflow-preview-gc.timer
+++ b/preview/uwflow-preview-gc.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Reconcile UWFlow previews every five minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Frontend previews currently lack an isolated running backend. This adds a manual, admin-approved deployment workflow that resolves exact frontend/backend commits, then provisions a Neon database branch and bounded API/Hasura containers on the existing EC2 instance. It creates a Vercel review URL whose API/GraphQL rewrites point to that PR's backend.

- A protected GitHub environment gates deployments; new commits require another approved request.
- EC2 enforces a capacity limit (one by default), memory/disk headroom, container limits, and a maximum 24-hour lifetime.
- A local systemd timer cleans up closed/merged PRs, expired previews, and failed attempts. Journaled ownership supports retries and lost cloud responses; EC2 compute stops before cloud cleanup.
- Adds optional TLS `DATABASE_URL` support to Go while preserving existing Postgres configuration, plus a synthetic Neon baseline bootstrap helper.

Start review with [the setup and validation guide](https://github.com/UWFlow/uwflow/blob/feat/admin-neon-previews/preview/README.md), then the GitHub workflow and `preview/controller.py`. The guide covers Neon, a dedicated Vercel project, restricted SSH, wildcard HTTPS, required admin reviewers, and the expiry timer. No cloud deployment or production configuration change has been performed.

Validation: 18 controller tests; full Go suite in the API Docker build; Hasura image build; actionlint; disposable Docker integration covering real migrations, signup, login, creating/editing reviews, and teardown. These checks also run in the added PR workflow.

Live Neon/Vercel/EC2 validation requires the documented one-time setup. This infrastructure does not fix Google OAuth or alter the frontend's existing local-only Playwright runner. Container resource limits are not a security boundary for hostile PR code on a production host. GHCR build artifacts remain in the registry; active preview resources and EC2 images are cleaned up.
