### PR TITLE
Add SSH command to export production snapshots for staging

### DIFF
--- a/script/backup-local.sh
+++ b/script/backup-local.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 
 DIR="$(dirname "$(realpath "$0")")"
 . "$DIR/common.sh"
+. "$DIR/postgres-dump.sh"
 
 # Bring backend environment variables into scope (POSTGRES_USER/DB/PORT).
 cd "$BACKEND_DIR"
@@ -48,9 +49,7 @@ fi
 
 echo "Dumping database '$POSTGRES_DB' to $FINAL ..."
 
-# No -t/-i on docker exec: a TTY would corrupt the binary dump on stdout.
-if $PREFIX docker exec postgres \
-     pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -p "$POSTGRES_PORT" -Fc \
+if dump_postgres -U "$POSTGRES_USER" -d "$POSTGRES_DB" -p "$POSTGRES_PORT" \
    > "$TMP"
 then
   # Verify it's a readable archive before promoting it. pg_dump can exit 0 and

--- a/script/postgres-dump.sh
+++ b/script/postgres-dump.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Shared by local backups and the installed staging exporter.
+dump_postgres() {
+  # No TTY: preserve the binary archive on stdout. PREFIX comes from common.sh.
+  ${PREFIX:-} docker exec \
+    -e PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=900000 -c lock_timeout=10000' \
+    postgres pg_dump -Fc "$@"
+}

--- a/script/staging-dump.md
+++ b/script/staging-dump.md
@@ -1,0 +1,49 @@
+# Stream a production snapshot to staging over SSH
+
+`staging-dump.sh` writes a PostgreSQL custom-format dump to stdout. It runs
+`pg_dump` inside the existing `postgres` container, requests a read-only database
+session, and creates no dump file on production. Errors go to stderr and a failed
+dump returns a nonzero status. No arguments are accepted.
+
+Install the script on production as a root-owned executable:
+
+```sh
+sudo install -o root -g root -m 0755 script/staging-dump.sh /usr/local/sbin/uwflow-staging-dump
+```
+
+The fixed container name is `postgres`, database is `flow`, and database user is
+`postgres`. Adjust these identifiers during installation if production differs.
+The PostgreSQL port is the client's default (5432). The receiving staging server
+must use a compatible `pg_restore` version, at least as new as the dump client.
+
+Create a dedicated SSH account, e.g. `staging-sync`, and grant only this exact
+root-owned command in sudoers (validate with `visudo`):
+
+```text
+staging-sync ALL=(root) NOPASSWD: /usr/local/sbin/uwflow-staging-dump ""
+```
+
+In that account's `authorized_keys`, prefix the staging public key with:
+
+```text
+restrict,command="sudo -n /usr/local/sbin/uwflow-staging-dump" ssh-ed25519 PUBLIC_KEY staging-sync
+```
+
+The account does not need membership in the Docker group. Keep the installed
+script and its parent directories unwritable by the SSH account. The forced
+command restricts this key to database exports and disables forwarding and PTYs.
+Protect access to this key: the snapshot includes production data.
+
+From staging, use a dedicated private key and a verified `known_hosts` entry:
+
+```sh
+ssh -T -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+  -o UserKnownHostsFile=./known_hosts -i ./id_ed25519 \
+  staging-sync@PRODUCTION_HOST /usr/local/sbin/uwflow-staging-dump > snapshot.pending.dump
+```
+
+Only use the output if SSH exits successfully. The staging sync runner should
+validate the archive, back up staging, restore with `pg_restore --exit-on-error`,
+apply the deployed revision's migrations, and run health checks. Replace the
+saved reset baseline only after success; restore the staging backup on failure.
+Production is exclusively the dump source, never a restore target.

--- a/script/staging-dump.md
+++ b/script/staging-dump.md
@@ -5,15 +5,22 @@
 session, and creates no dump file on production. Errors go to stderr and a failed
 dump returns a nonzero status. No arguments are accepted.
 
-Install the script on production as a root-owned executable:
+The dump command is shared with `backup-local.sh` through `postgres-dump.sh`.
+Both use a read-only session with a 15-minute statement timeout and a 10-second
+lock timeout. Local backups retain archive validation and atomic file promotion;
+the staging exporter streams the archive and omits ownership and ACLs.
+
+Install the script and shared helper on production as root-owned files:
 
 ```sh
+sudo install -d -o root -g root -m 0755 /usr/local/lib/uwflow
+sudo install -o root -g root -m 0644 script/postgres-dump.sh /usr/local/lib/uwflow/postgres-dump.sh
 sudo install -o root -g root -m 0755 script/staging-dump.sh /usr/local/sbin/uwflow-staging-dump
 ```
 
 The fixed container name is `postgres`, database is `flow`, and database user is
 `postgres`. Adjust these identifiers during installation if production differs.
-The PostgreSQL port is the client's default (5432). The receiving staging server
+The PostgreSQL port is fixed at 5432. The receiving staging server
 must use a compatible `pg_restore` version, at least as new as the dump client.
 
 Create a dedicated SSH account, e.g. `staging-sync`, and grant only this exact
@@ -30,7 +37,7 @@ restrict,command="sudo -n /usr/local/sbin/uwflow-staging-dump" ssh-ed25519 PUBLI
 ```
 
 The account does not need membership in the Docker group. Keep the installed
-script and its parent directories unwritable by the SSH account. The forced
+script, shared helper, and their parent directories unwritable by the SSH account. The forced
 command restricts this key to database exports and disables forwarding and PTYs.
 Protect access to this key: the snapshot includes production data.
 

--- a/script/staging-dump.sh
+++ b/script/staging-dump.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Install root-owned as /usr/local/sbin/uwflow-staging-dump on production.
+# stdout is ONLY a PostgreSQL custom-format archive; diagnostics go to stderr.
+set -eu
+if [ "$#" -ne 0 ]; then
+  echo 'This command accepts no arguments.' >&2
+  exit 2
+fi
+# Fixed deployment-specific identifiers; change these during installation if needed.
+# No TTY: binary pg_dump output is streamed unchanged over SSH.
+exec docker exec \
+  -e PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=900000 -c lock_timeout=10000' \
+  postgres pg_dump -U postgres -d flow -Fc --no-owner --no-acl

--- a/script/staging-dump.sh
+++ b/script/staging-dump.sh
@@ -6,8 +6,7 @@ if [ "$#" -ne 0 ]; then
   echo 'This command accepts no arguments.' >&2
   exit 2
 fi
+# Load only the root-owned installed helper, never a file from the checkout.
+. /usr/local/lib/uwflow/postgres-dump.sh
 # Fixed deployment-specific identifiers; change these during installation if needed.
-# No TTY: binary pg_dump output is streamed unchanged over SSH.
-exec docker exec \
-  -e PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=900000 -c lock_timeout=10000' \
-  postgres pg_dump -U postgres -d flow -Fc --no-owner --no-acl
+PREFIX='' dump_postgres -U postgres -d flow -p 5432 --no-owner --no-acl


### PR DESCRIPTION
Enable the staging machine to request a production database snapshot over SSH without opening a PostgreSQL port or storing a dump on production. The new argument-free command streams `pg_dump -Fc` from the existing Postgres container with a read-only session and bounded query/lock waits.

Includes installation instructions for a root-owned script, an exact sudoers command, and an SSH key restricted to running that dump command. Staging receives the binary archive and is responsible for validating it, backing up its database, and restoring locally.

Validation: `sh -n script/staging-dump.sh`; checked the argument-rejection path. Live production export remains pending installation and SSH access.
