### PR TITLE
Fix fresh development builds by pinning Air

### DIFF
--- a/flow/Dockerfile
+++ b/flow/Dockerfile
@@ -27,9 +27,10 @@ FROM golang:1.25-alpine AS dev
 
 WORKDIR /build
 
-# Install build dependencies and Air
-RUN apk add --no-cache git g++ poppler-dev && \
-    go install github.com/air-verse/air@latest
+# Install build dependencies separately so failures identify the failing step.
+RUN apk add --no-cache git g++ poppler-dev
+# Pin Air to a Go 1.25-compatible release; latest can require a newer toolchain.
+RUN go install github.com/air-verse/air@v1.63.0
 
 # Copy go.mod and go.sum for dependency caching
 COPY go.mod go.sum ./


### PR DESCRIPTION
Fresh `make start` builds install `air@latest` in a Go 1.25 image. Air's latest release now requires Go 1.26, making the build depend on a newer toolchain. Pin Air to v1.63.0, which supports Go 1.25, and separate Alpine package installation from Air installation so failures identify the failing step.

Validation: successfully built the complete development image with `docker build --target dev --progress plain -t uwflow-air-build-check ./flow`; `git diff --check` passed. The reported original failure was not reproduced to completion, and the running Compose stack was not changed.
