### PR TITLE
Run staging database exporter directly from production checkout

### DIFF
--- a/script/staging-dump.md
+++ b/script/staging-dump.md
@@ -10,43 +10,23 @@ Both use a read-only session with a 15-minute statement timeout and a 10-second
 lock timeout. Local backups retain archive validation and atomic file promotion;
 the staging exporter streams the archive and omits ownership and ACLs.
 
-Install the script and shared helper on production as root-owned files:
-
-```sh
-sudo install -d -o root -g root -m 0755 /usr/local/lib/uwflow
-sudo install -o root -g root -m 0644 script/postgres-dump.sh /usr/local/lib/uwflow/postgres-dump.sh
-sudo install -o root -g root -m 0755 script/staging-dump.sh /usr/local/sbin/uwflow-staging-dump
-```
+Run the exporter directly from the production checkout at
+`/home/ec2-user/uwflow/script/staging-dump.sh`. Keep `postgres-dump.sh` beside it;
+the exporter resolves the helper relative to its own location, regardless of the
+SSH session's working directory. No installation under `/usr/local` is needed.
+The current staging connection uses `ec2-user`, which has Docker access.
 
 The fixed container name is `postgres`, database is `flow`, and database user is
 `postgres`. Adjust these identifiers during installation if production differs.
 The PostgreSQL port is fixed at 5432. The receiving staging server
 must use a compatible `pg_restore` version, at least as new as the dump client.
 
-Create a dedicated SSH account, e.g. `staging-sync`, and grant only this exact
-root-owned command in sudoers (validate with `visudo`):
-
-```text
-staging-sync ALL=(root) NOPASSWD: /usr/local/sbin/uwflow-staging-dump ""
-```
-
-In that account's `authorized_keys`, prefix the staging public key with:
-
-```text
-restrict,command="sudo -n /usr/local/sbin/uwflow-staging-dump" ssh-ed25519 PUBLIC_KEY staging-sync
-```
-
-The account does not need membership in the Docker group. Keep the installed
-script, shared helper, and their parent directories unwritable by the SSH account. The forced
-command restricts this key to database exports and disables forwarding and PTYs.
-Protect access to this key: the snapshot includes production data.
-
 From staging, use a dedicated private key and a verified `known_hosts` entry:
 
 ```sh
 ssh -T -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
   -o UserKnownHostsFile=./known_hosts -i ./id_ed25519 \
-  staging-sync@PRODUCTION_HOST /usr/local/sbin/uwflow-staging-dump > snapshot.pending.dump
+  ec2-user@PRODUCTION_HOST /home/ec2-user/uwflow/script/staging-dump.sh > snapshot.pending.dump
 ```
 
 Only use the output if SSH exits successfully. The staging sync runner should

--- a/script/staging-dump.sh
+++ b/script/staging-dump.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
-# Install root-owned as /usr/local/sbin/uwflow-staging-dump on production.
+# Run from the production checkout alongside postgres-dump.sh.
 # stdout is ONLY a PostgreSQL custom-format archive; diagnostics go to stderr.
 set -eu
 if [ "$#" -ne 0 ]; then
   echo 'This command accepts no arguments.' >&2
   exit 2
 fi
-# Load only the root-owned installed helper, never a file from the checkout.
-. /usr/local/lib/uwflow/postgres-dump.sh
+# Resolve the helper relative to this script, independent of the working directory.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SCRIPT_DIR/postgres-dump.sh"
 # Fixed deployment-specific identifiers; change these during installation if needed.
 PREFIX='' dump_postgres -U postgres -d flow -p 5432 --no-owner --no-acl


### PR DESCRIPTION
The staging runner invokes `/home/ec2-user/uwflow/script/staging-dump.sh`, but the exporter required a helper installed under `/usr/local/lib/uwflow`. Resolve the helper relative to the exporter so the merged scripts run directly from the production checkout, and document that invocation.

Validation: shell syntax check passed; the updated checkout script successfully streamed a production snapshot over SSH. The staging runner path change is in jerryzhou196/server-infra#1, with all 11 staging unit tests passing.
