### PR TITLE
chore: sync .env.sample keys with .env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -32,3 +32,12 @@ SMTP_PORT=587
 SMTP_FROM=info@uwflow.com
 SMTP_USERNAME=test
 SMTP_PASSWORD=test
+
+# Managed Postgres (Neon). Leave blank when using the local `postgres` container.
+DATABASE_URL=
+DATABASE_URL_UNPOOLED=
+NEON_BRANCH=
+
+# Used by script/backup-db.sh to push dumps to S3.
+BACKUP_S3_BUCKET=
+BACKUP_S3_PREFIX=


### PR DESCRIPTION
`.env.sample` had drifted from the `.env` we actually run with. This adds the missing keys, with blank values so nothing secret lands in the repo.

**Added**
- `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_BRANCH` — managed Postgres (Neon); blank when using the local `postgres` container.
- `BACKUP_S3_BUCKET`, `BACKUP_S3_PREFIX` — read by `script/backup-db.sh`.

**Deliberately not added**
- `SENTRY_DSN` — it exists in the local `.env` but nothing in the tree reads it. The code reads `SENTRY_DSN_UW` (`flow/importer/uw/main.go:127`) and `SENTRY_DSN_API` (`flow/api/main.go:122`), both of which the sample already documents. Looks like a stale local leftover rather than a key worth documenting; happy to add it if it's used somewhere outside this repo.

After this, the only key-name difference between the two files is that `SENTRY_DSN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Fq4tgzd6TYXSbeorv8dhT